### PR TITLE
feat: Add method in Notification Manager for marking as `unread`

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@
                                     <a href="#" aria-label="Messages">
                                         <img src="static/images/icons/email_web_essential_icon.png" alt="Message icon" class="nav-icon" loading="lazy">
                                     </a>
-                                    <span class="notification-badge" data-count="2" aria-live="polite">2</span>
+                                    <span class="notification-badge" data-count="0" aria-live="polite"></span>
                                 </div>
                 
                                 <!-- Profile Picture Icon with Dropdown -->

--- a/static/css/css.css
+++ b/static/css/css.css
@@ -16,6 +16,7 @@
     --color-one: #8D6E63 ;
     --steel-blue: #2D3E50;
     --darker-red: #CC0000;
+    --deep-navy-blue: #0A2540;
     --white: #FFFFFF;
 
     --size-xs: 4px;
@@ -335,18 +336,14 @@ a:hover {
     transition: opacity 0.3s ease-in-out, visibility 0s 0.3s;
 }
 
-.dropdown.show {
+.dropdown.show,
+.notification-dropdown.show {
+    border: 2px solid lavender;
     opacity: 1;
     visibility: visible;
     transition: opacity 0.3s ease-in-out, visibility 0s 0s;
   }
   
-.notification-dropdown.show {
-    opacity: 1;
-    visibility: visible;
-    transition: opacity 0.3s ease-in-out, visibility 0s 0s;
-}
-
 
 .notification-dropdown {
     /* positioning */
@@ -464,12 +461,19 @@ a:hover {
     overflow: hidden;
  }
 
+ .no-notification p {
+    opacity: 0.5;
+ }
+
  .no-notification img {
     height: 60px;
     width: 60px;
     opacity: 0.4;
  }
 
+ .notification-id  {
+    color: var(--deep-navy-blue);
+ }
 
  /* The spinner */
 .spinner {

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -31,6 +31,7 @@ function handleEventDelegation(e) {
     handleProfileIconClick(e);
     handleNotificationIconClick(e);
     handleMarkAsRedClick(e);
+    handleMarkAsUnreadClick(e);
     handleDeleteLinkClick(e);
 }
 
@@ -76,8 +77,16 @@ function handleMarkAsRedClick(e) {
     const MARK_AS_READ_CLASS = "mark-as-read";
 
     if (e.target.classList.contains(MARK_AS_READ_CLASS)){
-
         notificationManager.markAsRead(e.target.dataset.id);
+    }
+}
+
+
+function handleMarkAsUnreadClick(e) {
+    const MARK_AS_UNREAD_CLASS = "mark-as-unread";
+
+    if (e.target.classList.contains(MARK_AS_UNREAD_CLASS)){
+        notificationManager.markAsUnRead(e.target.dataset.id);
     }
 }
 
@@ -86,7 +95,7 @@ function handleDeleteLinkClick(e) {
     const DELETE_CLASS = "delete";
 
     if (e.target.classList.contains(DELETE_CLASS)){
-        showSpinnerFor(spinnerElement)
+        showSpinnerFor(spinnerElement);
         notificationManager.deleteNotification(e.target.dataset.id);
     }
 }


### PR DESCRIPTION
Modified the `notificationManager` object to manage user notifications more effectively by adding:
- A `markAsUnread` function in `scripts.js` that marks a `read` notification as `unread`.
- A `_setReadStatus` function that handles marking a notification as either `read` or `unread`.
- Added a `insertBefore` in the `renderNotificationsToUI` to ensure that the latest notification are always on top

Added:
   - getNotificationIndexOrWarn: A method that retrieves the index of a particular notification and then used in places that require it.

**Workflow:**
- On page refresh, a new notification is sent, and the notification badge updates accordingly.
- New notifications are always placed on top ensuring the user always has the latest notifications.
- Users can interact with notifications via the UI.
- Users can mark notifications as `read` or `unread`.

Currently, notifications are generated on every page refresh for testing purposes. This behaviour will be removed in a future update.