### PR TITLE
**feat: Implement methods in Notification Manager for marking all as `unread`, marking all as `read`, and deleting all**

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,6 +128,12 @@
 
                                           
                                         </div>
+
+                                        <div class="notification-btns center" id="notification-btns" data-notification-count = "5">
+                                            <button type="button" class="small-btn mark-all-as-read-btn">Mark all as read</button>
+                                            <button type="button" class="small-btn mark-all-as-unread-btn">Mark all as unread</button>
+                                            <button type="button" class="small-btn delete-all-notifications-btn">Delete All</button>
+                                        </div>
                                     </div>
                                 </div>
                 

--- a/static/css/css.css
+++ b/static/css/css.css
@@ -308,6 +308,7 @@ a:hover {
     display: none;
   }
 
+  
  
   .dropdown {
 
@@ -491,6 +492,38 @@ a:hover {
     left: 60%;
     right: 50%;
     bottom: 50%;
+}
+
+
+
+/* notification buttons */ 
+.mark-all-as-read-btn {
+    background-color: #2D6A4F; /* Dark Green */
+  
+}
+
+.mark-all-as-unread-btn {
+    background-color: #6C9DC6; /* Soft Blue */
+   
+}
+
+.delete-all-notifications-btn {
+    background-color: #B74D57; /* Dark Red */
+    
+}
+
+
+.small-btn {
+    cursor: pointer;
+    color: white;
+    margin-right: var(--size-xs);
+    border: none;
+    padding: var(--size-sm);
+    
+}
+button:hover {
+    opacity: 0.8;
+    
 }
 
 

--- a/static/js/notification.js
+++ b/static/js/notification.js
@@ -1,10 +1,11 @@
-import { setLocalStorage, removeFromLocalStorage, getLocalStorage } from "./db.js"
+import { setLocalStorage, getLocalStorage } from "./db.js"
 import { generateRandomID, checkIfHTMLElement, findByIndex } from "./utils.js"
 
 
-const notificationElement = document.getElementById("notification");
-const notificationDropdownWrapper = document.querySelector(".notification-dropdown .wrapper")
-const noNotificationDiv           = document.getElementById("no-notification")
+const notificationElement         = document.getElementById("notification");
+const notificationDropdownWrapper = document.querySelector(".notification-dropdown .wrapper");
+const noNotificationDiv           = document.getElementById("no-notification");
+const notificationBtns            = document.getElementById("notification-btns");
 
 validatePageElements();
 
@@ -22,6 +23,9 @@ validatePageElements();
  * - deleteNotification(id): Deletes a notification.
  * - renderNotificationsToUI(): Renders notifications in the UI.
  * - updateNotificationBadgeIcon(count): Updates the notification badge.
+ * - markAllAsRead: Marks all notification as read
+ * - markAllAsUnread: Marks all notification as unread
+ * - deleteAllNotifications: Deletes all notifications
  *
  * Private Methods:
  * - _createNotification(notification): Creates a notification object.
@@ -150,12 +154,51 @@ export const notificationManager = {
     },
 
     /**
-     * Marks a notification as read by its ID. (To be implemented)
+     * Marks all notification as read 
+     */
+      markAllAsRead: () => {
+        if (notificationManager._notifications === null) {
+            notificationManager.getNotifications();
+        }
+
+        notificationManager._notifications.forEach((notifcation) => {
+            if (notifcation.unread) {
+                notifcation.unread = false;
+            }
+           
+        })
+        notificationManager._save();
+        notificationManager.renderNotificationsToUI();
+
+     },
+
+    /**
+     * Marks a notification as read by its ID.
      * @param {string} id - The notification ID.
      */
     markAsRead: (id) => {
        return notificationManager._setReadStatus(id, false);
     },
+
+
+    /**
+     * Marks all notification as unread 
+     */
+      markAllAsUnRead: () => {
+        if (notificationManager._notifications === null) {
+            notificationManager.getNotifications();
+        }
+
+        notificationManager._notifications.forEach((notifcation) => {
+            if (!notifcation.unread) {
+                notifcation.unread = true;
+            }
+          
+        })
+        notificationManager._save();
+        notificationManager.renderNotificationsToUI();
+
+     },
 
     /**
      * Marks a notification as read by its ID. (To be implemented)
@@ -190,7 +233,7 @@ export const notificationManager = {
     },
 
     /**
-     * Deletes a notification by its ID. (To be implemented)
+     * Deletes a notification by its ID.
      * @param {string} id - The notification ID.
      */
     deleteNotification: (id) => {
@@ -202,6 +245,17 @@ export const notificationManager = {
         };
         
         notificationManager._notifications = notificationManager._notifications.filter((notification) => notification.id != id)
+        notificationManager._save();
+        notificationManager.renderNotificationsToUI();
+        return true;
+    },
+
+     /**
+     * Deletes all notifications
+     */
+     deleteAllNotifications: () => {
+       
+        notificationManager._notifications = [];
         notificationManager._save();
         notificationManager.renderNotificationsToUI();
         return true;
@@ -219,6 +273,7 @@ export const notificationManager = {
         if (notificationManager._notifications.length === 0) {
             noNotificationDiv.style.display           = "block";
             notificationDropdownWrapper.style.display = "none"
+            notificationBtns.style.display            = "none";
             return;
         }
 
@@ -350,4 +405,5 @@ function validatePageElements() {
     checkIfHTMLElement(notificationElement, "The notification badge");
     checkIfHTMLElement(notificationDropdownWrapper, "The dropdown container");
     checkIfHTMLElement(noNotificationDiv, "The empty notifcation div");
+    checkIfHTMLElement(notificationBtns, "The notification btns")
 }

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -30,9 +30,12 @@ function handleEventDelegation(e) {
     console.log(e.target)
     handleProfileIconClick(e);
     handleNotificationIconClick(e);
-    handleMarkAsRedClick(e);
+    handleMarkAsReadClick(e);
     handleMarkAsUnreadClick(e);
     handleDeleteLinkClick(e);
+    handleDeleteAllNotificationsBtnClick(e);
+    handleMarkAllAsReadClick(e);
+    handleMarkAllAsUnReadClick(e);
 }
 
 
@@ -73,7 +76,7 @@ function handleNotificationIconClick(e) {
 }
 
 
-function handleMarkAsRedClick(e) {
+function handleMarkAsReadClick(e) {
     const MARK_AS_READ_CLASS = "mark-as-read";
 
     if (e.target.classList.contains(MARK_AS_READ_CLASS)){
@@ -81,9 +84,29 @@ function handleMarkAsRedClick(e) {
     }
 }
 
+function handleMarkAllAsReadClick(e) {
+    const MARK_AS_READ_CLASS = "mark-all-as-read-btn";
+
+    if (e.target.classList.contains(MARK_AS_READ_CLASS)){
+        showSpinnerFor(spinnerElement);
+        notificationManager.markAllAsRead();
+    }
+}
+
+
+function handleMarkAllAsUnReadClick(e) {
+    const MARK_AS_UNREAD_CLASS = "mark-all-as-unread-btn";
+
+    if (e.target.classList.contains(MARK_AS_UNREAD_CLASS)){
+        showSpinnerFor(spinnerElement);
+        notificationManager.markAllAsUnRead();
+    }
+}
+
+
 
 function handleMarkAsUnreadClick(e) {
-    const MARK_AS_UNREAD_CLASS = "mark-as-unread";
+    const MARK_AS_UNREAD_CLASS = "mark-all-as-unread-btn";
 
     if (e.target.classList.contains(MARK_AS_UNREAD_CLASS)){
         notificationManager.markAsUnRead(e.target.dataset.id);
@@ -99,6 +122,18 @@ function handleDeleteLinkClick(e) {
         notificationManager.deleteNotification(e.target.dataset.id);
     }
 }
+
+
+function handleDeleteAllNotificationsBtnClick(e) {
+    const DELETE_ALL_CLASS = "delete-all-notifications-btn";
+
+    if (e.target.classList.contains(DELETE_ALL_CLASS)){
+        showSpinnerFor(spinnerElement);
+        notificationManager.deleteAllNotifications();
+    }
+}
+
+
 
 /**
  * Hides the dropdown menu when the user scrolls the page.


### PR DESCRIPTION
Modified the `notificationManager` object to enhance user notification management by adding:
- A `markAllAsUnread` method to mark all notifications as `unread`.
- A `markAllAsRead` method to mark all notifications as `read`.

- Three buttons: `Mark all as read`, `Mark all as unread`, and `Delete all` along with the appropriate CSS

- On page refresh, a new notification is generated, and the notification badge updates accordingly.
- New notifications always appear at the top, ensuring users see the latest updates first.
- Users can interact with notifications via the UI.
- Users can mark notifications as `read` or `unread` individually.
- Users can mark all notifications as `read`, `unread`, or delete all notifications in one go.

Currently, notifications are generated on every page refresh for testing purposes. This behaviour will be removed in a future update.