### PR TITLE
Add payment card to wallet UI

### DIFF
--- a/static/js/add-new-card.js
+++ b/static/js/add-new-card.js
@@ -145,8 +145,7 @@ function addCardToUIWallet(wallet, card) {
             
             const error = "Something went wrong and the card wasn't added to the wallet";
             logError("handleCardFormSubmission", error);
-            showFormErrorMsg(true, "An error occured, please refresh the page and try again");
-            // removeWalletFromStorage(); // uncomment this if an error occurs run and then comment it again
+            showFormErrorMsg(true, error.message);
             return false;
         }
 
@@ -156,9 +155,7 @@ function addCardToUIWallet(wallet, card) {
     } catch (error) {
 
         logError("handleCardFormSubmission", error);
-        showFormErrorMsg(true, "An error occured, please refresh the page and try again");
-        removeWalletFromStorage();
-        
+        showFormErrorMsg(true, error.message);        
         return false;
         
     }

--- a/static/js/add-new-card.js
+++ b/static/js/add-new-card.js
@@ -142,11 +142,11 @@ function addCardToUIWallet(wallet, card) {
     try {
         const isCardAdded = wallet.addCardToWallet(card.cardNumber);
         if (!isCardAdded) {
-
+            
             const error = "Something went wrong and the card wasn't added to the wallet";
             logError("handleCardFormSubmission", error);
             showFormErrorMsg(true, "An error occured, please refresh the page and try again");
-            removeWalletFromStorage();
+            // removeWalletFromStorage(); // uncomment this if an error occurs run and then comment it again
             return false;
         }
 
@@ -154,7 +154,7 @@ function addCardToUIWallet(wallet, card) {
         return true;
 
     } catch (error) {
-        
+
         logError("handleCardFormSubmission", error);
         showFormErrorMsg(true, "An error occured, please refresh the page and try again");
         removeWalletFromStorage();


### PR DESCRIPTION
- Removed the `removeLocalStorage` method as it was blocking important error messages, such as "You exceed the maximum number of cards that can be stored in the wallet."
- Ran the command `localStorage.removeItem("wallet")` to clear the outdated wallet and allow the system to create a new wallet on refresh with correct wallet struture.
