### PR TITLE
- Renamed `showRemoveAlert` to `showConfirmationAlert` for a more generic use case.

### DIFF
--- a/static/js/add-new-card.js
+++ b/static/js/add-new-card.js
@@ -34,7 +34,7 @@ submitBtnElement.addEventListener("click", handleSubmitBtnClick);
 notificationManager.setKey(config.NOTIFICATION_KEY);
 
 
-export function handleCardFormSubmission(e, wallet) {
+export async function handleCardFormSubmission(e, wallet) {
 
     e.preventDefault();
     const CREATE_CARD_BTN_ID = "create-card-btn";
@@ -64,7 +64,27 @@ export function handleCardFormSubmission(e, wallet) {
             return;
         }
 
-        const card = generateCardFromParsedData(parsedCardData);
+        let card;
+
+        try {
+            card = generateCardFromParsedData(parsedCardData);
+        } catch (error) {
+            const resp = await AlertUtils.showConfirmationAlert({
+                confirmButtonText: "Load Card",
+                denyButtonText: "Cancel",
+                title: "An existing card is already in the system. Do you want to load it into the wallet?",
+                cancelMessage: "The card was not loaded.",
+                messageToDisplayOnSuccess: "Card successfully loaded.",
+                icon: "info",
+            
+            });
+
+            if (resp) {
+                card = Card.getByCardNumber(parsedCardData.cardNumber);
+            } else {
+                card = false;
+            }
+        }
 
         if (!card) {
             isSubmitButtonClick = false;
@@ -263,7 +283,7 @@ function generateCardFromParsedData(parsedCardData) {
 
     } catch (error) {
         showFormErrorMsg(true, error.message);
-        return false;
+        throw new Error("Card already exists");
     }
 }
 

--- a/static/js/alerts.js
+++ b/static/js/alerts.js
@@ -18,12 +18,14 @@ export const AlertUtils = {
         });
     },
 
-    async showRemovalAlert({showDenyButton = true,  
+    async showConfirmationAlert({showDenyButton = true,  
         showCancelButton = true, 
         confirmButtonText = "Remove", 
         denyButtonText = "Don't remove", 
         title = "Do you want to remove these cards from your wallet?",
         icon = "info",
+        cancelMessage = "Cards were not removed",
+        messageToDisplayOnSuccess="removed!",
       } = {}) {
           return Swal.fire({
               title: title,
@@ -34,10 +36,10 @@ export const AlertUtils = {
               icon: icon,
           }).then((result) => {
               if (result.isConfirmed) {
-                  Swal.fire("Removed!", "", "success");
+                  Swal.fire(messageToDisplayOnSuccess, "", "success");
                   return true;
               } else if (result.isDenied) {
-                  Swal.fire("Cards were not removed", "", "info");
+                  Swal.fire(cancelMessage, "", "info");
                   return false;
               }
               return null;

--- a/static/js/wallet.js
+++ b/static/js/wallet.js
@@ -380,7 +380,7 @@ export class Wallet extends DataStorage {
      * This method checks if the wallet has room for more cards, if the card is not 
      * already added, and if the card number is valid. If all conditions are met, 
      * the card is added to the wallet and returned as an object. If any condition fails, 
-     * an error is thrown.
+     * an error is thrown. 
      *
      * @param {string} cardNumber - The card number to add to the wallet.
      * @returns {Object|boolean} - Returns the card object if successfully added to the wallet, 

--- a/static/js/walletUI.js
+++ b/static/js/walletUI.js
@@ -243,7 +243,7 @@ export async function handleRemoveCardButtonClick(e) {
             return;
         }
 
-      const resp = await AlertUtils.showRemovalAlert();
+      const resp = await AlertUtils.showConfirmationAlert();
 
       if (resp) {
           const [isRemoved, cardNumbers] = wallet.removeAllCardsMarkedForRemoval();


### PR DESCRIPTION
- Added functionality to allow previously removed cards or existing cards to be re-added to the wallet.

Previously, once a card was removed from the wallet, it could not be added back, because the function only allowed unique cards.
This resulted in an issue where attempting to re-add a removed card or an existing card that wasn't in the wallet
 triggered a notification stating that it already existed in the system.

The new functionality resolves this by:
✅ Allowing a removed card or an existing card to be reloaded into the wallet, provided it is not already present.
✅ Doing nothing if the card is already in the wallet.

1. The user visits the site.
2. They click **Add New Card** and add multiple cards (if they have none) after verifying their PIN.
3. They click **Remove Card** to delete selected cards.
4. They attempt to re-add a deleted card and succeed.