### PR TITLE
- Implemented logic to allow users to block or unblock a card from th…

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -47,6 +47,8 @@ import { handleSidBarCardClick,
          handleCloseCardManagerButton,
          handleNotYetImplementedFunctionality } from "./sidebarCard.js";
 
+import { handleTransferBlock } from "./sidebarCardBlocking.js";
+
 
 // elements
 const dashboardElement       = document.getElementById("virtualbank-dashboard");
@@ -99,6 +101,7 @@ function handleEventDelegation(e) {
     handleSidBarCardClick(e);
     handleCloseCardManagerButton(e);
     handleNotYetImplementedFunctionality(e);
+    handleTransferBlock(e);
         
 }
 

--- a/static/js/sidebarCard.js
+++ b/static/js/sidebarCard.js
@@ -11,6 +11,13 @@ const sideBarCardContainerElement = document.getElementById("sidebar-card");
 const cardInfoDivElement          = document.getElementById("card-info");
 
 
+export const selectedSidebarCard = {
+    clicked: false,
+    cardNumber: '',
+    cardType: '',
+    cardStatus: null
+  };
+  
 
 validatePageElements();
 
@@ -30,7 +37,8 @@ export function handleSidBarCardClick(e) {
         return;
     }
   
- 
+    
+
    
     const cardNumber = cardElement.dataset.cardNumber;
     const card       = Card.getByCardNumber(cardNumber);
@@ -42,7 +50,12 @@ export function handleSidBarCardClick(e) {
     }
 
     toggleOfAllCardsExceptForClicked(cardElement);
-    
+    renderCardToUI(card);
+
+}
+
+
+export function renderCardToUI(card) {
     const cardData  = prepareCardData(card);
 
     if (!cardData || typeof cardData !== "object") {
@@ -52,13 +65,52 @@ export function handleSidBarCardClick(e) {
 
     }
 
-    cardData.cardNumber = maskCreditCardNo(cardData.cardNumber)
+    updateSelectedSidebarCardState(cardData);
+    cardData.cardNumber  = maskCreditCardNo(cardData.cardNumber)
     const userCardElement = cards.createCardDiv(cardData);
     cards.placeCardDivIn(sideBarCardContainerElement, userCardElement, true);
 
     handleIsCardBlockedImg(userCardElement, cardData);
-    renderCardDetails(cardData)
+    renderCardDetails(cardData);
+}
 
+
+/**
+ * Updates the shared `selectedSidebarCard` state object.
+ *
+ * This function acts as a persistence layer for sidebar card interactions,
+ * allowing different parts of the UI to access the currently selected card.
+ * It simplifies the management of related actions such as `transfer`, `delete`,
+ * `fund`, and `block`, since the selected card's state is centralised and ensures
+ * when any of these buttons are clicked, the app knows the exact card details.
+ *
+ * @param {Object} cardData - The card data for the clicked sidebar card.
+ * Must contain `cardNumber`, `cardType`, and `isCardBlocked`.
+ */
+function updateSelectedSidebarCardState(cardData) {
+    if (!cardData || typeof cardData !== "object" ) {
+        warnError("updateSelectedSidebarCardState", "The card data is empty");
+        return;
+    }
+
+    selectedSidebarCard.cardNumber = cardData.cardNumber;
+    selectedSidebarCard.clicked    = true;
+    selectedSidebarCard.cardStatus = cardData.isCardBlocked;
+    selectedSidebarCard.cardType   = cardData.cardType;
+
+}
+
+
+/**
+ * Returns the current state of the selected sidebar card.
+ *
+ * Useful for checking which card is currently selected and accessing its metadata
+ * such as card number, status, or type.
+ *
+ * @returns {Object} The current `selectedSidebarCard` state object.
+ */
+export function getSelectedSidebarCardState() {
+    return selectedSidebarCard;
 }
 
 
@@ -201,9 +253,9 @@ function toggleCardManagerDiv(show=true) {
 
 export function handleCloseCardManagerButton(e) {
     const CLOSE_BTN_ID = "close-card";
-    console.log(e.target)
     if (e.target.id === CLOSE_BTN_ID) {
         toggleCardManagerDiv(false);
+        return;
     }
 }
 
@@ -237,12 +289,12 @@ function showInvalidCardAlertMsg() {
 
 // Not yet implemented
 export function handleNotYetImplementedFunctionality(e) {
-    const BLOCK_BUTTON_ID    = "block-card";
+
     const TRANSFER_BUTTON_ID = "transfer-card-amount";
     const ADD_BUTTON_ID      = "add";
     const DELETE_BUTTON_ID   = "delete";
 
-    if (e.target.id === BLOCK_BUTTON_ID || e.target.id === TRANSFER_BUTTON_ID ||
+    if ( e.target.id === TRANSFER_BUTTON_ID ||
         e.target.id === ADD_BUTTON_ID || e.target.id === DELETE_BUTTON_ID) {
         AlertUtils.showAlert({title: "Not yet implemented",
             text: "You seeing this because the functionality is not yet implemented",

--- a/static/js/sidebarCardBlocking.js
+++ b/static/js/sidebarCardBlocking.js
@@ -1,0 +1,65 @@
+
+import { getSelectedSidebarCardState, renderCardToUI } from "./sidebarCard.js";
+import { Card } from "./card.js";
+import { logError } from "./logger.js";
+import { notificationManager } from "./notificationManager.js";
+import { config } from "./config.js";
+import { AlertUtils } from "./alerts.js";
+
+notificationManager.setKey(config.NOTIFICATION_KEY);
+
+
+export async function handleTransferBlock(e) {
+    
+    const BLOCK_BUTTON_ID = "block-card";
+
+    if (e.target.id !== BLOCK_BUTTON_ID) {
+        return;
+    }
+
+    
+    const card = Card.getByCardNumber(getSelectedSidebarCardState().cardNumber);
+   
+    if (!card) {
+        logError("handleTransferblock", "The card wasn't found");
+        return;
+    }
+
+    let msg;
+   
+    if (!card.isBlocked){
+            const resp = await AlertUtils.showConfirmationAlert({
+                            title: "Are you sure you want to block your virtual card?",
+                            icon: "warning",
+                            confirmButtonText: "Block",
+                            messageToDisplayOnSuccess: "Your card has been successfully blocked.",
+                            cancelMessage: "No changes were made. Your card remains active.",
+                            denyButtonText: "Cancel"
+                        });
+        
+        if (resp) {
+        
+            msg = `Your card was blocked on ${new Date().toLocaleString()}.
+                        You won’t be able to send or receive money until it’s unblocked.`;
+            card.freezeCard();
+            renderCardToUI(card);
+            notificationManager.add(msg);
+        }
+       
+    } else {
+        const msg = `Your card has been unblocked as of ${new Date().toLocaleString()}.
+                     You can now send and receive money again.`;
+
+        card.unfreezeCard();
+        AlertUtils.showAlert({
+            title: "Card unblocked",
+            text: "Your card is now active and ready to use.",
+            confirmButtonText: "OK",
+            icon: "success"
+        });
+        renderCardToUI(card);
+        notificationManager.add(msg);
+    }
+  
+    
+}


### PR DESCRIPTION
…e sidebar.

- **Added** the ability for users to block or unblock cards. After blocking or unblocking a card, a notification is sent to the user.

**Modifications:**
- **Extracted the state management logic**:
    - `selectedSidebarCard`: Tracks the card selected from the sidebar, making it available across pages without querying the DOM repeatedly. This state allows manipulation of the selected card via actions like `transfer`, `fund`, `block`, and `delete`, as long as the page is not refreshed.
    - `updateSelectedSidebarCardState`: Updates the state whenever a card is selected from the sidebar. This function is called by `handleSideBarClick` and handles the UI rendering via `renderToCardUI`.
    - `getSelectedSidebarState`: Retrieves the `selectedSidebarCard` object, ensuring the data persists across pages until the page is refreshed.

**Code extraction:**
- **Extracted UI rendering** logic from `handleSideBarClick` into a new function called `renderToCardUI`. This allows rendering of the selected card to happen independently of the entire sidebar click logic and can be reused elsewhere, such as when blocking or unblocking a card.

- **Added `handleTransferBlock` function**: Manages the blocking and unblocking of cards when clicked.

- Although a card is blocked, users can still send money to it. The implementation to prevent this action will be handled in a future update.

1. Go to the wallet's card section (assuming there are cards).
2. Click on any card.
3. In the dialog box, click `block` or `unblock`.
4. After the card is blocked or unblocked, a notification is sent to the user.