### PR TITLE
- Implemented logic to prevent blocked cards from being used in fund …

### DIFF
--- a/index.html
+++ b/index.html
@@ -832,12 +832,12 @@
                         <span class="center steel-blue">You are operating in preview mode. Changes will not be saved until the <span class="bold padding-xsm"> Transfer </span> button is clicked.</span>
                     </div>
                     
-                    <div class="transfer-error-msg">
+                    <div class="transfer-error-msg" id="transfer-error-msg">
                         <p class="red center capitalize" id="transfer-messages-id">Insufficient funds</p>
                         <p class="red center" id="transfer-error-card-msg-id"></p>
                     </div>
 
-                    <h3 class="logo padding-bottom-md center">EUSBC</h3>
+                    <h3 class="logo padding-bottom-md center margin-top-sm">EUSBC</h3>
                     <h4 class="margin-bottom-lg center">Transfer funds</h4>
 
                     <div class="four-column-grid" id="transfer-fund-amount">

--- a/static/css/css.css
+++ b/static/css/css.css
@@ -1449,9 +1449,9 @@ input::placeholder {
     display: block;
 }
 
-
+.transfer-error-msg span,
 .transfer-error-msg p {
-    font-size: 0.85rem;
+    font-size: 0.82rem;
 }
 
 
@@ -1495,10 +1495,12 @@ input::placeholder {
     color: white;
 }
 
+
 #transfer-waiting-msg,
 #transfer-close-btn {
     display: none;
 }
+
 
 #transfer-waiting-msg.show,
 #transfer-close-btn.show {

--- a/static/js/pin.js
+++ b/static/js/pin.js
@@ -4,9 +4,9 @@ import { sanitizeText } from "./utils.js";
 import { Wallet } from "./wallet.js";
 import { logError } from "./logger.js";
 import { showNewCardForm} from "./add-new-card.js";
-import { AlertUtils } from "./alerts.js";
 import { cards } from "./cardsComponent.js";
 import { handleFundDiv } from "./fund-account.js";
+import { getSelectedSidebarCardState } from "./sidebarCard.js";
 
 
 const ADD_FUNDS_ID     = "add-funds";
@@ -80,6 +80,7 @@ export function handlePinShowage(e, wallet) {
    }
 
    if (id === TRANSFER_FUNDS ) {
+        getSelectedSidebarCardState().isTransferWindowOpen = true;
         dimBackground(dimBackgroundElement, true);
         transferDivElement.classList.add("show");
         closeDivs([addNewCardDivElement, addFundsDivElement, removeCardsDivElement ]);

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -62,6 +62,8 @@ dashboardElement.addEventListener("input", handleEventDelegation);
 
 
 
+
+
 function handleEventDelegation(e) {
         
     handleProfileIconClick(e);
@@ -104,10 +106,4 @@ function handleEventDelegation(e) {
     handleTransferBlock(e);
         
 }
-
-
-
-
-
-
 

--- a/static/js/sidebarCard.js
+++ b/static/js/sidebarCard.js
@@ -6,16 +6,14 @@ import { AlertUtils } from "./alerts.js";
 import { prepareCardData } from "./walletUI.js";
 import { maskCreditCardNo } from "./utils.js";
 
+
 const sideBarCardsManagerElement  = document.getElementById("sidebar-cards");
 const sideBarCardContainerElement = document.getElementById("sidebar-card");
 const cardInfoDivElement          = document.getElementById("card-info");
 
 
 export const selectedSidebarCard = {
-    clicked: false,
-    cardNumber: '',
-    cardType: '',
-    cardStatus: null
+    isTransferWindowOpen: false,
   };
   
 
@@ -38,8 +36,6 @@ export function handleSidBarCardClick(e) {
     }
   
     
-
-   
     const cardNumber = cardElement.dataset.cardNumber;
     const card       = Card.getByCardNumber(cardNumber);
 
@@ -88,16 +84,13 @@ export function renderCardToUI(card) {
  * Must contain `cardNumber`, `cardType`, and `isCardBlocked`.
  */
 function updateSelectedSidebarCardState(cardData) {
+
     if (!cardData || typeof cardData !== "object" ) {
         warnError("updateSelectedSidebarCardState", "The card data is empty");
         return;
     }
 
-    selectedSidebarCard.cardNumber = cardData.cardNumber;
-    selectedSidebarCard.clicked    = true;
-    selectedSidebarCard.cardStatus = cardData.isCardBlocked;
-    selectedSidebarCard.cardType   = cardData.cardType;
-
+    selectedSidebarCard.lastCardClickeCardNumber = cardData.cardNumber;
 }
 
 
@@ -247,6 +240,17 @@ function handleIsCardBlockedSpanText(cardSpanElement, card) {
 }
 
 function toggleCardManagerDiv(show=true) {
+
+    if (show && getSelectedSidebarCardState().isTransferWindowOpen) {
+        AlertUtils.showAlert({
+            title: "Transfer Window Is Open",
+            text: "You cannot open the Card Manager while the transfer window is active. Please close the transfer window and try again.",
+            icon: "warning",
+            confirmButtonText: "OK",
+        });
+        
+       return;
+    }
     show ? sideBarCardsManagerElement.classList.add("show") : sideBarCardsManagerElement.classList.remove("show")
 }
 

--- a/static/js/sidebarCardBlocking.js
+++ b/static/js/sidebarCardBlocking.js
@@ -6,7 +6,10 @@ import { notificationManager } from "./notificationManager.js";
 import { config } from "./config.js";
 import { AlertUtils } from "./alerts.js";
 
+
 notificationManager.setKey(config.NOTIFICATION_KEY);
+
+const selectedSidebarCard = getSelectedSidebarCardState();
 
 
 export async function handleTransferBlock(e) {
@@ -18,7 +21,7 @@ export async function handleTransferBlock(e) {
     }
 
     
-    const card = Card.getByCardNumber(getSelectedSidebarCardState().cardNumber);
+    const card = Card.getByCardNumber(selectedSidebarCard.lastCardClickeCardNumber);
    
     if (!card) {
         logError("handleTransferblock", "The card wasn't found");
@@ -43,6 +46,8 @@ export async function handleTransferBlock(e) {
                         You won’t be able to send or receive money until it’s unblocked.`;
             card.freezeCard();
             renderCardToUI(card);
+           
+            updateSideBarCardState(card)
             notificationManager.add(msg);
         }
        
@@ -57,9 +62,24 @@ export async function handleTransferBlock(e) {
             confirmButtonText: "OK",
             icon: "success"
         });
+        updateSideBarCardState(card);
         renderCardToUI(card);
         notificationManager.add(msg);
     }
   
     
+}
+
+
+export function updateSideBarCardState(card) {
+
+    selectedSidebarCard[card.cardNumber] = {
+
+        cardNumber: card.cardNumber,
+        cardStatus: card.isBlocked ? "blocked" : "active",
+        cardType: card.cardType,
+        id: card.id,
+    }
+
+  
 }

--- a/static/js/wallet.js
+++ b/static/js/wallet.js
@@ -650,6 +650,10 @@ export class Wallet extends DataStorage {
             const card = Card.getByCardNumber(cardNumber);
 
             if (card) {
+                if (card.isBlocked) {
+                    console.log(`No funds were added to the card with number #${card.cardNumber} because it was blocked`);
+                    return;
+                }
                 card.addAmount(transferAmount);
                 updatedCards.push(card);
                 this._updateCardInWallet(card);

--- a/static/js/walletUI.js
+++ b/static/js/walletUI.js
@@ -10,9 +10,7 @@ import { Card } from "./card.js";
 import { removeCardTable, cards } from "./cardsComponent.js";
 import { AlertUtils } from "./alerts.js";
 import { notificationManager } from "./notificationManager.js";
-
-
-
+import { updateSideBarCardState } from "./sidebarCardBlocking.js";
 
 
 const cardDisplayArea  = document.getElementById("cards");
@@ -81,11 +79,23 @@ function handleInitialSetup() {
 
     loadUserCardsInUI(wallet);
     updateAllWalletDashoardText(wallet)
+    updateCardStateObjectWithBlockCards();
 }
 
 
 
-
+function updateCardStateObjectWithBlockCards() {
+    const cards = Card.getAllBlockCards();
+    if (cards) {
+        const numOfBlockedCards = cards.length;
+        console.log(`Loading ${numOfBlockedCards} blocked ${numOfBlockedCards > 1 ? 'cards' : 'card'}`);
+        
+        for (const card of cards) {
+            updateSideBarCardState(card);
+        }
+        console.log("Done, blocked cards loaded to the system")
+    }
+}
 
 export function handleWalletPin(e) {
     handlePinShowage(e, wallet);


### PR DESCRIPTION
…transfers (both sending and receiving).

- **`updateCardStateObjectWithBlockedCards`**: When the application is loaded, this function retrieves all the block cards and then stores them in a persistent state object that can be accessed in any page and in any function regardless of a refresh.

- **`_prepareCardsForBulkSave`**: Modified the method to skip any blocked card from being funded.

- **`updateCardSelectionCount`**:
  - Integrated:
    - `getSelectedSidebarCardState`: Prevents count increase for blocked cards.
    - `showBlockedCardFundingError`: Displays error and toggles the blocked card message when selected.

- **`handleTransferCloseIcon`**: Added reset functionality: ```js getSelectedSidebarCardState().isTransferWindowOpen = false; // tells the application that transfer window is closed resetSelectFields(); toggleCardAreaDisplay(false); toggleTransferMessage(false); clearBlockedCardMessages(); updatePerCountCardValue(RESET_VALUE); updateTransferCardCount(RESET_VALUE); updateTransferAmountLabelValueUI(RESET_VALUE); ``` These ensure all values and messages reset when the transfer window closes.

- **Helper Functions**:
  - `clearBlockedMessages`: Clears all existing blocked messages.
  - `addMessages`: Appends new messages to the transfer window.
  - `toggleMessages`: Toggles the visibility of a message and returns a boolean indicating its state.

- **`updateSideBarCardState`**: Maintains a persistent state for card block status across pages and synced with localStorage. Used by transfer functions to avoid hitting localStorage repeatedly, every time it needs to check if a card is blocked or unblocked.

- **Added Flag**:
  - `isTransferWindowOpen` to `selectedSidebarCard`, preventing card block/unblock operations while the transfer window is open.

- **`toggleCardManagerDiv`**: Prevents the Card Manager from opening if the transfer window is active, with a user-facing alert.

- Set `isTransferWindowOpen = true` when the transfer window is opened.

- **`getAllBlockedCards`**: Fetches all blocked cards to initialise sidebar card state on app load.

1. Go to the Wallet’s **Card Section** (with cards present).
2. Click on any card in the sidebar to open the card manager dialog.
3. Click **Block** to block the card.
4. A notification is sent upon blocking/unblocking.
5. Close the Card Manager dialog and open the **Transfer Window**.
6. Choose **Bank** or **Wallet** in the **From** dropdown.
7. Select cards in the **To** list.
8. If a blocked card is selected, a warning message appears preventing the action.
9. Try opening any sidebar card while the transfer window is active — an alert informs you that this is not allowed.

---