### PR TITLE
Initial implementation of the sidebar card manipulation feature, allowing users to fund their card

### DIFF
--- a/index.html
+++ b/index.html
@@ -807,7 +807,7 @@
                         
                             <div class="form-group flex-direction-column">
                                 <label for="amount">Amount</label>
-                                <input type="number" name="amount" id="fund-amount" required step="0.01" min="0.01" max="100000000">
+                                <input type="number" name="amount" id="fund-card-amount" required step="0.01" min="0.01" max="100000000">
                             </div>
                         
                             <button type="submit" id="fund-account-btn" class="margin-top-md btn-small">Fund</button>
@@ -990,6 +990,32 @@
                     </div>
                     
                 </div>
+
+                  <!-- fund my card -->
+                  <div id="fund-my-card">
+                    <div class="window-close flex-end">
+                        <img src="static/images/icons/window-close.svg" alt="Window" class="icon window-close-icon" id="fund-card-close-icon">
+                    </div>
+                    <p class="error-msg red small-text center" id="fund-my-card-error">You cannot add funds because your card has been blocked</p>
+                    <h2 class="center logo">EUSBC</h2>
+                    <h3 class="center capitalize green">Fund my card</h3>
+                        <div class="header center">
+                           
+                            <img src="static/images/icons/credit-card.svg" alt="" class="add-fund-icon">
+                        </div>
+                       
+
+                        <form action="" method="post" id="add-fund-form">
+                         
+                            <div class="form-group flex-direction-column">
+                                <label for="amount">Amount</label>
+                                <input type="number" name="amount" id="fund-amount" required step="0.01" min="0.01" max="100000000">
+                            </div>
+                        
+                            <button type="submit" id="fund-account-btn" class="margin-top-md btn-small">Fund</button>
+                        </form>
+                        
+                 </div>
 
 
     </main>

--- a/static/css/css.css
+++ b/static/css/css.css
@@ -146,6 +146,10 @@ select {
     overflow-wrap: anywhere;
 }
 
+.small-text {
+    font-size: 0.85rem;
+}
+
 /* padding */
 
 .padding-xsm {
@@ -504,6 +508,7 @@ button:hover {
 #transfer.show,
 #transfer-close-icon.show,
 #transfer-progress-container.show,
+#fund-my-card.show,
 #sidebar-cards.show {
     border: 2px solid lavender;
     opacity: 1;
@@ -1164,6 +1169,7 @@ tr:hover {
     display: none;
 }
 
+#fund-my-card-error,
 .form-error-msg {
     display: none;
 }
@@ -1171,9 +1177,11 @@ tr:hover {
 
 
 .spinner3.show,
+#fund-my-card-error.show,
 .form-error-msg.show {
     display: block;
 }
+
 
 .d-none {
     display: none;
@@ -1344,7 +1352,7 @@ input::placeholder {
 
 
 /* fund account */
-
+#fund-my-card,
 #fund {
     width: 30%;
     position: fixed;
@@ -1361,6 +1369,7 @@ input::placeholder {
     
 }
 
+.add-fund-icon,
 #add-fund-icon {
     height: 200px;
     width: 200px;

--- a/static/js/card.js
+++ b/static/js/card.js
@@ -42,15 +42,26 @@ export class Card extends DataStorage {
     }
 
     addAmount(amount) {
+        
+        if (this.isBlocked) {
+            throw new Error("The card has been blocked an no funds can be added");
+        }
+
         this._amountManager.validateAmount(amount);
-        this._amountManager.addAmount(amount)
+        this._amountManager.addAmount(amount);
+        this.save();
 
     }
 
     deductAmount(amount) {
 
+        if (!this.isBlocked) {
+            throw new Error("The card has been blocked an no funds can be deducted");
+        }
+
         this._amountManager.validateAmount(amount)
         this._amountManager.deductAmount(amount);
+        this.save();
 
     }
 

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -45,9 +45,13 @@ import { handleTransferButtonClick,
 import { handleTransferCloseButton } from "./progress.js";
 import { handleSidBarCardClick,
          handleCloseCardManagerButton,
-         handleNotYetImplementedFunctionality } from "./sidebarCard.js";
+         handleNotYetImplementedFunctionality,
+        handleAddFundCardButtonClick,
+        handleAddCloseButtonIconClick,
+        } from "./sidebarCard.js";
 
 import { handleTransferBlock } from "./sidebarCardBlocking.js";
+import { handleAddFundToCardFormButtonClick } from "./sideBarFundCard.js";
 
 
 // elements
@@ -104,6 +108,10 @@ function handleEventDelegation(e) {
     handleCloseCardManagerButton(e);
     handleNotYetImplementedFunctionality(e);
     handleTransferBlock(e);
-        
+    handleAddFundCardButtonClick(e);
+    handleAddCloseButtonIconClick(e);
+    handleAddFundCardButtonClick(e);
+    handleAddFundToCardFormButtonClick(e);
+    
 }
 

--- a/static/js/sideBarFundCard.js
+++ b/static/js/sideBarFundCard.js
@@ -1,0 +1,101 @@
+import { checkIfHTMLElement } from "./utils.js";
+import { parseFormData } from "./formUtils.js";
+import { Card } from "./card.js";
+import { getSelectedSidebarCardState } from "./sidebarCard.js";
+import { logError } from "./logger.js";
+import { AlertUtils } from "./alerts.js";
+import { renderCardToUI } from "./sidebarCard.js";
+
+const fundMyCardFormElement  = document.getElementById("add-fund-form");
+const fundMyCardErrorElement = document.getElementById("fund-my-card-error");
+
+
+validatePageElements();
+
+
+export function handleAddFundToCardFormButtonClick(e) {
+
+    const ADD_FUND_BUTTON_ID = "fund-account-btn";
+
+    if (e.target.id === ADD_FUND_BUTTON_ID) {
+        if (fundMyCardFormElement.checkValidity()) {
+
+            const formData   = new FormData(fundMyCardFormElement);
+            const required   = ["amount"]
+            const parsedData = parseFormData(formData, required);
+
+            const resp = handleAddFundingToCard(parsedData);
+            if (resp) {
+                AlertUtils.showAlert({
+                    title: "Card successfully funded",
+                    text: "Your card was successfully funded",
+                    icon: "success",
+                    confirmButtonText: "Great",
+                })
+            }
+
+           
+        } else {
+            fundMyCardFormElement.reportValidity();
+        }
+    }
+}
+
+
+function handleAddFundingToCard(parsedData) {
+
+    if (!parsedData || typeof parsedData !== "object") {
+        logError("addFundingToCard", `Expected an object containing the amount but got object with type ${typeof parsedData} `);
+        return;
+    }
+
+    if (!parsedData.hasOwnProperty("amount")) {
+        logError("addFundingToCard", `Expected a property called "amount" inside the parseData object but it couldn't be found: Object ${parsedData} `);
+        return;
+    }
+
+    const cardNumber = getSelectedSidebarCardState().lastCardClickeCardNumber;
+
+    if (!cardNumber) {
+        logError("addFundingToCard", "Expected a card number, since a card from the sidebar was clicked");
+        return;
+    }
+
+    const card = Card.getByCardNumber(cardNumber); 
+
+    if (!card) {
+        logError("addFundingToCard", "Expected a card object but got nothing");
+        return;
+    }
+
+    // throws and error if the card is blocked
+    try {
+       card.addAmount(parsedData.amount);
+       toggleErrorMsg(false);
+       renderCardToUI(card);
+       return true;
+    } catch (error) {
+        updateFundingErrorMsg(error.msg);
+        toggleErrorMsg(true);
+    }
+}
+
+
+function updateFundingErrorMsg(msg) {
+    if (!msg || typeof msg !== "object") {
+        logError("updateFundingErrorMsg", `Expect a string but got object with object ${msg} with type ${typeof msg}`);
+        return;
+    }
+    fundMyCardErrorElement.textContent = msg;
+}
+
+
+function toggleErrorMsg(show) {
+    show ? fundMyCardErrorElement.classList.add("show") : fundMyCardErrorElement.classList.remove("show");
+}
+
+
+function validatePageElements() {
+    checkIfHTMLElement(fundMyCardFormElement, "The funding my card form");
+    checkIfHTMLElement(fundMyCardErrorElement, "The error message for funding card");
+}

--- a/static/js/sidebarCard.js
+++ b/static/js/sidebarCard.js
@@ -10,6 +10,8 @@ import { maskCreditCardNo } from "./utils.js";
 const sideBarCardsManagerElement  = document.getElementById("sidebar-cards");
 const sideBarCardContainerElement = document.getElementById("sidebar-card");
 const cardInfoDivElement          = document.getElementById("card-info");
+const fundMyCardElement           = document.getElementById("fund-my-card");
+const fundMyCardCloseElement      = document.getElementById("fund-card-close-icon");
 
 
 export const selectedSidebarCard = {
@@ -165,6 +167,7 @@ function renderCardDetails(card) {
     
 }
 
+
 function renderCardInfo(cardFields) {
     
     const CARD_ID = "card-info__card-status";
@@ -239,6 +242,7 @@ function handleIsCardBlockedSpanText(cardSpanElement, card) {
     card.isCardBlocked ? cardSpanElement.classList.add("red") : cardSpanElement.classList.add("green");
 }
 
+
 function toggleCardManagerDiv(show=true) {
 
     if (show && getSelectedSidebarCardState().isTransferWindowOpen) {
@@ -295,25 +299,51 @@ function showInvalidCardAlertMsg() {
 export function handleNotYetImplementedFunctionality(e) {
 
     const TRANSFER_BUTTON_ID = "transfer-card-amount";
-    const ADD_BUTTON_ID      = "add";
     const DELETE_BUTTON_ID   = "delete";
 
-    if ( e.target.id === TRANSFER_BUTTON_ID ||
-        e.target.id === ADD_BUTTON_ID || e.target.id === DELETE_BUTTON_ID) {
+    if ( e.target.id === TRANSFER_BUTTON_ID || e.target.id === DELETE_BUTTON_ID) {
         AlertUtils.showAlert({title: "Not yet implemented",
             text: "You seeing this because the functionality is not yet implemented",
             icon: "info",
             confirmButtonText: "Ok"
         })
     }
+
 }
 
+
+export function handleAddFundCardButtonClick(e) {
+    const BUTTON_ID = "add";
+
+    if (e.target.id !== BUTTON_ID) {
+        return;
+    }
+ 
+    toggleAddMyCardForm(true);
+}
+
+
+export function handleAddCloseButtonIconClick(e) {
+    const ADD_FUND_ID = "fund-card-close-icon";
+
+    if (e.target.id === ADD_FUND_ID ) {
+        toggleAddMyCardForm(false);
+    }
+    
+}
+
+
+function toggleAddMyCardForm(show) {
+    show ? fundMyCardElement.classList.add("show") : fundMyCardElement.classList.remove("show");
+}
 
 
 function validatePageElements() {
     checkIfHTMLElement(sideBarCardsManagerElement, "The sidebar card manager");
     checkIfHTMLElement(sideBarCardContainerElement, "The sidebar container");
     checkIfHTMLElement(cardInfoDivElement, "The card info element container");
+    checkIfHTMLElement(fundMyCardElement, "The funding my card form");
+    checkIfHTMLElement(fundMyCardCloseElement, "The add fund close icon")
   
 
 }


### PR DESCRIPTION
directly from the sidebar.

---

- Added ability to fund a card from the sidebar
- Responsive UI to support sidebar card interaction

---

**HTML & CSS**
- Created a funding form structure that appears when the `Fund` button is clicked.
- Applied styling for a visually pleasing and consistent experience.

**JS: `sideBarCard.js`**
- `handleAddFundCardButtonClick`: Triggers the funding form display when the user clicks the `Fund` button in the card manager.
- `toggleAddMyCardForm`: Displays or hides the funding form.
- `handleAddCloseButtonIconClick`: Closes the funding form when the close icon is clicked.

**JS: `sideBarFundCard.js`**
- `handleAddFundToCardFormButtonClick`: Validates form input when the `Fund` button is clicked.
- `handleAddFundingToCard`: Handles the logic for updating the card amount in localStorage.
- `updateFundingErrorMsg`: Updates and shows error messages.
- `toggleErrorMsg`: Toggles error visibility.

**JS: `card.js`**
- Modified `addAmount` and `deductAmount` to:
  - Check if a card is blocked before allowing funds to be added or removed.
  - Throw an error if the card is blocked, allowing UI to handle it gracefully.

---

**When card is not blocked:**
1. User clicks a card in the sidebar.
2. Card manager opens.
3. User clicks `Fund`.
4. Funding form is displayed.
5. User enters an amount and confirms.
6. Card balance updates successfully.

**When card is blocked:**
1. User selects a card and blocks it.
2. Attempts to fund the card using the form.
3. An error message appears stating the card is blocked and cannot be funded.

---

- Future commits will include full support for `Transfer` and `Delete` interactions.