### PR TITLE
Fixed a bug where the logo would disappear each time the card's money…

### DIFF
--- a/static/js/sidebarCardUpdate.js
+++ b/static/js/sidebarCardUpdate.js
@@ -8,6 +8,7 @@ import { formatCurrency, stripAmountFromCurrency } from "./utils.js";
 import { removeCardBlockStatus, applyCardBlockStatus } from "./cardsComponent.js";
 
 
+
 notificationManager.setKey(config.NOTIFICATION_KEY);
 
 
@@ -19,7 +20,7 @@ function updateCardInPlace(card) {
     }
 
     // Update balance
-    const balanceElement = cardElement.querySelector(".card-amount");
+    const balanceElement = cardElement.querySelector(".card-amount .card-amount");
  
     if (balanceElement) {
         balanceElement.textContent = formatCurrency(stripAmountFromCurrency(card.cardAmount));


### PR DESCRIPTION
… balance was updated.

This happened because both the `div` and the `span` shared the same class name `.card-amount`, and the code was only querying the first match. As a result, the amount was being placed in the
 container instead of the intended span, causing the logo to vanish.

```js
const balanceElement = cardElement.querySelector(".card-amount"); // selects the first match (div)
```

```js
const balanceElement = cardElement.querySelector(".card-amount .card-amount"); // selects the span within
```

Now the balance correctly updates inside the span, which preserves the logo display.