### PR TITLE
feat: allow users to delete cards from wallet and local storage

### DIFF
--- a/applicationTest.js
+++ b/applicationTest.js
@@ -954,7 +954,7 @@ class Wallet extends DataStorage {
      * @param {string} cardNumber - The card number to be removed.
      * @throws {Error} If the card number is not a valid string.
      */
-    removeCard(cardNumber) {
+    removeCardInWallet(cardNumber) {
         if (typeof cardNumber !== "string" || !cardNumber.trim()) {
             throw new Error(`Invalid card number. Expected a non-empty string but got ${typeof cardNumber}`);
         }
@@ -1746,7 +1746,7 @@ function removeSingleCardFromWalletTest(card, wallet) {
     console.log(`💳 Attempting to remove card belonging to: ${card.cardHolderName} (Card Number: ${card.cardNumber})`);
 
     console.log("🔄 Removing card from the wallet...");
-    wallet.removeCard(card.cardNumber);
+    wallet.removeCardInWallet(card.cardNumber);
 
     if (wallet.numOfCardsInWallet < initialNumOfCards) {
         console.log(`✅ Test Successful: Card removed successfully. Total cards remaining: ${wallet.numOfCardsInWallet}`);

--- a/static/js/add-new-card.js
+++ b/static/js/add-new-card.js
@@ -167,10 +167,13 @@ export function handleCVCInputField(e) {
 function addCardToUIWallet(wallet, card) {
 
     try {
+
+          
         const isCardAdded = wallet.addCardToWallet(card.cardNumber);
+      
         if (!isCardAdded) {
             
-            const error = "Something went wrong and the card wasn't added to the wallet";
+            const error = `Something went wrong and the card wasn't added to the wallet. Tried to add card number ${card} `;
             logError("handleCardFormSubmission", error);
             showFormErrorMsg(true, error.message);
             return false;

--- a/static/js/alerts.js
+++ b/static/js/alerts.js
@@ -52,12 +52,14 @@ export const AlertUtils = {
         confirmButtonText = "Remove", 
         denyButtonText = "Don't remove", 
         title = "Do you want to remove these cards from your wallet?",
+        text  = "This action is irreversable and cannot be undone",
         icon = "info",
         cancelMessage = "Cards were not removed",
         messageToDisplayOnSuccess="removed!",
       } = {}) {
           return Swal.fire({
               title: title,
+              text: text,
               showDenyButton: showDenyButton,
               showCancelButton: showCancelButton,
               confirmButtonText: confirmButtonText,

--- a/static/js/card.js
+++ b/static/js/card.js
@@ -112,6 +112,7 @@ export class Card extends DataStorage {
 
     static deleteCard(cardNumber) {
         const cardDetails = getLocalStorage(CARD_STORAGE_KEY);
+
         if (Array.isArray(cardDetails) || typeof cardDetails !== "object") {
             logError("wallet.deleteCard", `Expected an object but got type ${typeof cardDetails}`);
             return null;
@@ -123,11 +124,14 @@ export class Card extends DataStorage {
             return;
         }
         if (card.isBlocked) {
-            throw new Error(`The card with number #${card.cardNumber} couldn't be deleted because it has been blocked. Unblock and try again`);
+            throw new Error(`Card Blocked: Card #${card.cardNumber} cannot be deleted because it is currently blocked. Please unblock the card and try again.`);
         } 
 
-        const userCard = cardDetails[CARD_STORAGE_KEY][cardNumber];
-        const updatedCardDetails = excludeKey(userCard, cardNumber);
+        if (card.balance > 0) {
+            throw new Error(`Card Not Empty: Card #${card.cardNumber} cannot be deleted because it still has a balance. Please transfer the remaining funds before trying again.`);
+        }
+        
+        const updatedCardDetails  = excludeKey(cardDetails, cardNumber);
         setLocalStorage(CARD_STORAGE_KEY, updatedCardDetails);
         return true;
 
@@ -351,4 +355,5 @@ export class Card extends DataStorage {
         
     }
 
+   
 }

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -45,7 +45,7 @@ import { handleTransferButtonClick,
 import { handleTransferCloseButton } from "./progress.js";
 import { handleSidBarCardClick,
         handleCloseCardManagerButton,
-        handleNotYetImplementedFunctionality,
+        handleSideBarDeleteCard,
         handleAddFundCardButtonClick,
         handleAddCloseButtonIconClick,
         handleTransferAmountButtonClick,
@@ -114,7 +114,7 @@ function handleEventDelegation(e) {
    handleTransferCloseIcon(e);
    handleSidBarCardClick(e);
    handleCloseCardManagerButton(e);
-   handleNotYetImplementedFunctionality(e);
+   handleSideBarDeleteCard(e);
    handleTransferBlock(e);
    handleAddFundCardButtonClick(e);
    handleAddCloseButtonIconClick(e);

--- a/static/js/sideBarTransfer-funds.js
+++ b/static/js/sideBarTransfer-funds.js
@@ -505,7 +505,6 @@ export function handleCardTransferAmountFormButtonClick(e) {
             transferToRightInstitution(amount);  
 
         } catch (error) {
-            console.log(amount)
             handleAlertMessage(error.message);
             return;
         }
@@ -557,7 +556,7 @@ function transferToRightInstitution(amountToTransfer) {
     }
 
  
-    ({ wallet, bankAccount } = getWalletAndBankAccount()); // Ensure we using the latest data;
+    ({ wallet, bankAccount } = getWalletAndBankAccount()); // Ensure we using the latest data
     
 
     switch(CardTransfer.transferringTo) {

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -584,3 +584,21 @@ export function formatCurrency(amount, locale='en-GB', currency='GBP') {
       maximumFractionDigits: 2,
     });
 }
+
+
+export function parseErrorMessage(errorMsg) {
+    if (typeof errorMsg !== "string") return null;
+
+    const [titleRaw, textRaw] =  errorMsg.split(":");
+
+    if (titleRaw === undefined || textRaw === undefined) {
+        return {title: "Oops, something went wrong", text: ""};
+    }
+
+    const title  = titleRaw.trim();
+    const text   = textRaw.trim();
+
+    return {title, text}
+    
+} 
+

--- a/static/js/walletUI.js
+++ b/static/js/walletUI.js
@@ -185,17 +185,20 @@ export const walletDashboard = {
 };
 
 
-function updateAllWalletDashoardText(wallet) {
-    const profile = profileCache.getProfileData();
+export function updateAllWalletDashoardText(wallet, updateProfile=true) {
+   
     walletDashboard.updateNumOfCardsText(wallet);
     
-    try {
-        const fullName                = combineFirstAndLastName(toTitle(profile.firstName), toTitle(profile.surname));
-        walletNameElement.textContent = fullName;
-    } catch (error) {
-        walletNameElement.textContent = "User";
+    if (updateProfile) {
+        const profile = profileCache.getProfileData();
+        try {
+            const fullName                = combineFirstAndLastName(toTitle(profile.firstName), toTitle(profile.surname));
+            walletNameElement.textContent = fullName;
+        } catch (error) {
+            walletNameElement.textContent = "User";
+        }
     }
-
+  
     walletDashboard.updateWalletAccountBalanceText(wallet);
     walletDashboard.updateBankAccountBalanceText(wallet);
     walletDashboard.updateTotalCardAmountText(wallet);


### PR DESCRIPTION
Implemented a feature to delete a card from the wallet. A card can only be deleted if:
- It is **not blocked**, and
- It has **no remaining funds**.

If either of these conditions is not met, a warning message is displayed instead of deleting the card.

**Modified** `wallet.js`:
- Renamed `removeCard` → `removeCardInWallet`
- Renamed `removeAllCards` → `removeAllCardsInWallet`

  **Reason for renaming:**
  - To clarify that these methods only remove cards from the **wallet**, not from **localStorage**.
  - A new method `removeCardCompletely` was introduced to delete a card from both the wallet and localStorage. Renaming helps distinguish between methods more clearly.

**Added** `sidebarCard.js`:
- Introduced `handleCardDeletion` function, which handles the logic when the user selects the delete option in the card sidebar.
- This function performs validation and shows appropriate messages or deletes the card if eligible.

---

1. Navigate to the page.
2. Ensure you have at least one card in your wallet, or create a new card.
3. Click the card.
4. In the pop-up card window, select the `Delete` option.
5. The card will be deleted.
6. A notification confirms that your card has been deleted.

---

1. Navigate to the page.
2. Ensure you have at least one card, or create one.
3. Click the card.
4. Block the card.
5. Click the `Delete` button.
6. A message will appear stating that **blocked cards cannot be deleted**.

---

1. Navigate to the page.
2. Ensure you have at least one card, or create one.
3. Click the card.
4. Add funds to it.
5. Attempt to delete it.
6. A message will appear stating that **cards with funds cannot be deleted**.

7. Transfer all funds to a bank, wallet, or another card.
8. Attempt deletion again.
9. The card will be deleted.
10. A notification confirms successful deletion.

---

- Card deletion is user-friendly and includes clear notifications and validations.
- UI/UX prevents accidental deletion of important or locked cards.