### PR TITLE
feat: Add virtual bank login page and navigation links

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1106,21 +1106,33 @@ footer {
 
 #register-btn {
     background: var(--green-600);
-    color: white;
-    font-size: 1.1rem;
-    cursor: pointer;
+
 }
 
+#wallet-login-btn:hover,
 #register-btn:hover {
     background: #0B1220;
     color: white;
 }
 
+#register-btn,
+#wallet-login-btn {
+    color: white;
+    font-size: 1.1rem;
+    cursor: pointer;
+    font-size: 1.1rem;
+}
+
+#wallet-login-btn {
+    background: var(--blue-600);
+}
+
+
 .register__container h1 {
     font-size: 1.2rem;
 }
 
-#wallet-register-form {
+.authentication-form {
     box-shadow: var(--box-shadow-tietary);
     width: 35%;
     margin: auto;
@@ -1131,10 +1143,7 @@ footer {
 
 }
 
-#wallet-register-form h1 {
-    font-size: 1.2rem;
-}
- 
+
 
 
 
@@ -1256,13 +1265,18 @@ label {
 }
 
 
+#login {
+    margin-top: 108px;
+    margin-bottom: 108px;
+}
+
+
 /* info p-tag */
 #wallet-bank-connection-info {
     width: 70%;
     line-height: 1.7;
     margin: auto;
 }
-
 
 .moodle {
     
@@ -1282,9 +1296,6 @@ label {
     text-transform: capitalize;
 }
 
-.registration-help h1 {
-    font-size: 1.4rem;
-}
 
 .registration-help p {
     line-height: 1.5;
@@ -1312,8 +1323,10 @@ label {
 }
 
 
+/* help icon */
 .fa-circle-question {
-    cursor: pointer;;
+    cursor: pointer;
+    color: var(--blue-600);
 }
 
 #wallet-register-code-container {
@@ -1324,8 +1337,9 @@ label {
     position: absolute;
     right: 0;
     top: 6px;
-    color: var(--blue-600);
+  
 }
+
 #wallet-code {
     text-transform: uppercase;
     color: rgba(0, 0, 0, 0.7); 
@@ -1336,4 +1350,22 @@ label {
 .field-check {
     color: var(--red);
     display: none;
+}
+
+.auth-link:hover {
+    text-decoration: underline;
+}
+
+
+
+#dim {
+    position: fixed;  
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);  
+    z-index: 100000; 
+    display: none;
+    pointer-events: none;
 }

--- a/static/js/authentication/walletRegister.js
+++ b/static/js/authentication/walletRegister.js
@@ -1,14 +1,13 @@
 import CheckFrontEndPasswordStrength from "../utils/password/checkPasswordStrength.js";
-import { applyDashToInput } from "../utils.js";
+import { applyDashToInput, dimBackground } from "../utils.js";
 
 const walletHelperMoodle          = document.getElementById("wallet-registration-code-explained");
 const registerFormSectionElement  = document.getElementById("register");
-const walletCodeInputFieldElement = document.getElementById("wallet-code")
-
+const walletCodeInputFieldElement = document.getElementById("wallet-code");
+const dimBackgroundElement        = document.getElementById("dim");
 
 // TODO one time function checker to be added later. This is a one time check that checks if the elements are available before the addEventListener is called
 registerFormSectionElement.addEventListener("click", handleDelegation)
-
 walletCodeInputFieldElement.addEventListener("click",  handleCodeInputField);
 walletCodeInputFieldElement.addEventListener("input",  handleCodeInputField);
 
@@ -44,9 +43,11 @@ function handleDelegation(e) {
    
     if (!helperIcon) {
         walletHelperMoodle.classList.remove("show");
+        dimBackground(dimBackgroundElement, false);
         return;
     }
 
+    dimBackground(dimBackgroundElement, true);
     walletHelperMoodle.classList.add("show");
 }
 

--- a/virtual-bank-homepage.html
+++ b/virtual-bank-homepage.html
@@ -11,7 +11,7 @@
 </head>
 
 <body>
-
+   
     <header class="mb-24">
 
         <nav aria-label="Main navigation">
@@ -50,7 +50,7 @@
                         <li>
                             <div class="authentication-btns flex-grid two-column-grid" aria-label="Authentication"
                                 id="authentication-btns">
-                                <a href="/login" class="nav-link center authenticate-btn text-uppercase" id="login-btn">
+                                <a href="/virtual-bank-login.html" class="nav-link center authenticate-btn text-uppercase" id="login-btn">
                                     Login
                                 </a>
 

--- a/virtual-bank-login.html
+++ b/virtual-bank-login.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="static/css/style.css">
+    <link rel="stylesheet" href="static/vendor/fontawesome/css/all.min.css">
+    <link rel="shortcut icon" href="static/images/virtual-bank-logo.png" type="image/x-icon">
+    <title>Virtual bank login page</title>
+</head>
+
+<body>
+    <header class="mb-24">
+        <nav aria-label="Main navigation" class="white-bg">
+            <div class="nav-container flex-grid two-column-grid">
+
+                <!-- Logo / Home -->
+                <div class="head">
+                    <a href="/" class="nav-link pt-8 bold" id="virtual-bank-logo">
+                        <img src="static/images/virtual-bank-logo.png" alt="Virtual Bank home" class="logo" />
+                    </a>
+                </div>
+
+                <!-- Navigation Links -->
+                <div class="body">
+                    <ul class="flex-grid two-column-grid" role="list">
+
+                        <li>
+                            <a href="/virtual-bank-homepage.html" class="nav-link light-bold capitalise" id="nav-home">
+                                Back to Home
+                            </a>
+                        </li>
+
+                        <li>
+                            <a href="/vritual-bank-register.html" class="nav-link light-bold capitalise"
+                                id="nav-security">
+                                Signup
+                            </a>
+                        </li>
+
+                    </ul>
+                </div>
+
+            </div>
+        </nav>
+    </header>
+
+    <main>
+
+        <section id="login" aria-labelledby="login-heading">
+
+            <div class="login__container">
+
+                <h1 id="login-heading" class="capitalise center header-7">
+                    Log in to your account
+                </h1>
+
+                <p id="login-description" class="mt-4 center">
+                    Access your account and manage your finances
+                </p>
+
+
+                <form action="" method="post" id="wallet-login-form" class="p-24 white-bg authentication-form"
+                    aria-describedby="login-description" role="form">
+
+                    <div class="form-group">
+
+                        <!-- Email -->
+                        <div class="flex-row flex-grid">
+                            <label for="email">
+                                Email <span aria-hidden="true">*</span>
+                            </label>
+                            <input type="email" name="email" id="email" required aria-required="true" maxlength="30">
+                        </div>
+
+                        <!-- Passwords -->
+                        <div class="flex-row flex-grid">
+
+                            <label for="password">
+                                Password <span aria-hidden="true">*</span>
+                            </label>
+                            <input type="password" name="password" id="password" required aria-required="true"
+                                aria-describedby="password-rules" minlength="8" maxlength="25">
+
+                        </div>
+
+
+                    </div>
+
+                    <!-- Submit btn-->
+                    <div class="button mt-8 mb-8">
+                        <button type="submit" id="wallet-login-btn" class="large-btn capitalise center auth-btn">
+                            Login
+                        </button>
+                    </div>
+
+                    <hr class="dividor mt-4 mb-4" aria-hidden="true">
+
+                    <div id="already-signed-up" class="center">
+
+                        <span> Don't have account?</span>
+                        <a href="/vritual-bank-register.html" class="auth-link">Sign up</a>
+                    </div>
+
+                </form>
+
+            </div>
+
+
+        </section>
+
+
+    </main>
+
+
+    <!-- The footer section -->
+    <footer>
+
+        <div class="footer__container">
+
+            <div class="footer__header">
+                <img src="static/images/virtual-wallet-logo.png" alt="The virtual logo" class="footer-logo">
+
+            </div>
+
+
+            <div class="flex-grid five-column-grid" id="footer-sections">
+
+                <!-- About us column -->
+                <div class="col flex-grid" id="about-us">
+                    <h1 class="footer-head pb-16">About us</h1>
+                    <a href="#" class="footer-link">Our company</a>
+                    <a href="#" class="footer-link">Careers</a>
+                    <a href="#" class="footer-link">Security</a>
+                    <a href="#" class="footer-link">Investor relations</a>
+
+                </div>
+
+                <!-- services column -->
+                <div class="col flex-grid" id="services">
+                    <h1 class="footer-head pb-16">services</h1>
+                    <a href="#" class="footer-link">Online banking</a>
+                    <a href="#" class="footer-link">Mobile app</a>
+                    <a href="#" class="footer-link">Credit app</a>
+                    <a href="#" class="footer-link">Loans and mortgages</a>
+                </div>
+
+                <!-- support column -->
+                <div class="col flex-grid" id="support">
+                    <h1 class="footer-head pb-16">support</h1>
+                    <a href="#" class="footer-link">FAQs</a>
+                    <a href="#" class="footer-link">Help Center</a>
+                    <a href="#" class="footer-link">Contact us</a>
+                    <a href="#" class="footer-link">Live chat</a>
+                </div>
+
+                <div class="col flex-grid" id="resources">
+                    <h1 class="footer-head pb-16">resources</h1>
+                    <a href="#" class="footer-link">Financial Education</a>
+                    <a href="#" class="footer-link">Blog</a>
+                    <a href="#" class="footer-link">News and Insight</a>
+                    <a href="#" class="footer-link">Calculators</a>
+                </div>
+
+                <div class="col" id="download-app">
+                    <h1 class="footer-head">Download our app</h1>
+
+                    <div id="apps" class="flex-grid two-column-grid">
+                        <img src="static/images/footer-icons/appStore.svg" alt="" class="footer-icon">
+                        <img src="static/images/footer-icons/googlePlay.svg" alt="" class="footer-icon">
+                    </div>
+
+
+                </div>
+            </div>
+
+            <div class="socials copyright flex-grid two-column-grid pb-24">
+
+                <div class="socials four-column-grid">
+                    <a href="#"><img src="static/images/icons/facebook.svg" alt="facebook" class="social-icon"></a>
+                    <a href="#"><img src="static/images/icons/instagram.svg" alt="facebook" class="social-icon"></a>
+
+                </div>
+
+                <div class="copyright four-column-grid">
+                    <a href="#" class="copyright-link"><span class="copyright-date">@2026 </span>Virtual bank. All
+                        rights reserved</a>
+                    <a href="#" class="copyright-link footer-link">Privacy policy</a>
+                    <a href="#" class="copyright-link footer-link">Terms of use</a>
+
+                </div>
+            </div>
+
+        </div>
+
+    </footer>
+
+
+</body>
+
+</html>

--- a/vritual-bank-register.html
+++ b/vritual-bank-register.html
@@ -11,6 +11,7 @@
 </head>
 
 <body>
+    <div class="dim-background" id="dim"></div>
     <header class="mb-24">
         <nav aria-label="Main navigation" class="white-bg">
             <div class="nav-container flex-grid two-column-grid">
@@ -24,7 +25,7 @@
 
                 <!-- Navigation Links -->
                 <div class="body">
-                    <ul class="flex-grid three-column-grid" role="list">
+                    <ul class="flex-grid two-column-grid" role="list">
 
                         <li>
                             <a href="/virtual-bank-homepage.html" class="nav-link light-bold capitalise" id="nav-home">
@@ -32,15 +33,8 @@
                             </a>
                         </li>
 
-
                         <li>
-                            <a href="/help" class="nav-link light-bold capitalise" id="nav-help">
-                                Help
-                            </a>
-                        </li>
-
-                        <li>
-                            <a href="/login" class="nav-link light-bold capitalise" id="nav-security">
+                            <a href="/virtual-bank-login.html" class="nav-link light-bold capitalise" id="nav-security">
                                 Login
                             </a>
                         </li>
@@ -66,7 +60,7 @@
                     Sign up to start managing your finances
                 </p>
 
-                <form action="" method="post" id="wallet-register-form" class="p-24 white-bg"
+                <form action="" method="post" id="wallet-register-form" class="p-24 white-bg authentication-form"
                     aria-describedby="register-description" role="form">
 
                     <div class="form-group">
@@ -92,15 +86,19 @@
 
                         <!-- Wallet code -->
                         <div class="flex-row flex-grid" id="wallet-register-code-container">
-                             <span role="button" tabindex="0" aria-label="What is a wallet registration code?" id="wallet-helper-icon">
-                                <i class="fa-solid fa-circle-question" aria-hidden="true" id="wallet-register-code-info"></i>
+                            <span role="button" tabindex="0" aria-label="What is a wallet registration code?"
+                                id="wallet-helper-icon">
+                                <i class="fa-solid fa-circle-question" aria-hidden="true"
+                                    id="wallet-register-code-info"></i>
                             </span>
                             <label for="wallet-code">
                                 Wallet registration code
                             </label>
 
-                            <input type="text" name="wallet_code" id="wallet-code" aria-describedby="wallet-code-help" maxlength="34" minlength="34" spellcheck="false">
-                            <small id="wallet-unique-code" class="field-check">The wallet registration code is invalid</small>
+                            <input type="text" name="wallet_code" id="wallet-code" aria-describedby="wallet-code-help"
+                                maxlength="34" minlength="34" spellcheck="false">
+                            <small id="wallet-unique-code" class="field-check">The wallet registration code is
+                                invalid</small>
                             <small id="wallet-code-help" class="italic">
                                 If you have already created your wallet, enter the wallet registration ID.
                             </small>
@@ -205,12 +203,14 @@
 
                     <hr class="dividor mt-4 mb-4" aria-hidden="true">
 
-                    <div id="already-signed-up" class="center">
-                        <span>
-                            Already have an account?
-                            <a href="#">Log in</a>
-                        </span>
+
+                    <div id="already-have-an-account" class="center">
+
+                        <span> Already have an account?</span>
+                        <a href="/virtual-bank-login.html" class="auth-link">Login</a>
                     </div>
+
+
 
                 </form>
 
@@ -221,24 +221,29 @@
 
         <section class="moodle registration-help centered" id="wallet-registration-code-explained">
             <div class="container">
-                <h1 class="center mt-24 mb-24 capitalise">Wallet registration code explained</h1>
+                <h1 class="center mt-24 mb-24 capitalise header-7">Wallet registration code explained</h1>
 
                 <h2 class="mt-8">What is a wallet registration code?</h2>
                 <p>
-                    A wallet registration code is a twenty nine digit unique code created for you after the creation of your wallet.
+                    A wallet registration code is a twenty nine digit unique code created for you after the creation of
+                    your wallet.
                     It allows you to sign up for a bank account without reusing your email or username.
                 </p>
 
                 <h2 class="mb-24">Do I need wallet registration code?</h2>
 
                 <p>
-                    The short answer is no. You only need a wallet registration code if you created a wallet first and are then signing up for a virtual bank.
-                </p>
-                <p class="mt-8">
-                    If you are registering for a bank/bank account first, you can skip the registration code and continue
-                    using your username, email address, and password.
+                    The short answer is no. You only need a wallet registration code if you created a wallet first and
+                    are then signing up for a virtual bank.
                 </p>
 
+                <p class="mt-4">
+                    If you are registering for a bank account first, you can simply continue using your username, email
+                    address, and password, no registration code is required.
+                    If you have already signed up but choose not to use your registration code, you can still register
+                    using a different email address and username.
+                    Just keep in mind that this may mean having more details to remember later.
+                </p>
                 <h2 class="mt-8">When is a registration code needed?</h2>
                 <p>
                     The registration code is only needed if you created a wallet before registering for a bank
@@ -260,7 +265,7 @@
                 <h2 class="mt-8">What happens when I enter the registration code?</h2>
                 <p>
                     The code is checked instantly, without refreshing the page. Once confirmed, your email and
-                    username are locked, and you can safely set your password to
+                    username fields are locked, and you can safely set your password to
                     complete your wallet registration.
                 </p>
 


### PR DESCRIPTION
Add a login page for the virtual bank and make it accessible from both the home page and the registration page.

- Created `virtual-bank-login.html` with a login form
- Added CSS styling for the login form
- Linked the login page from the virtual bank home page
- Linked the login page from the virtual bank registration page

- Imported the `dimBackground` utility into `walletRegister.js` and applied it within `handleDelegation` to dim the page when the wallet helper icon is clicked
- Added CSS styles to support the dimmed background effect

- Updated the helper message in the “Wallet registration code explained” modal
- Users can navigate to the login page from both the virtual bank home page and the registration page
- Wallet helper interactions now visually dim the background allowing only the modal to show


## Outcome

- Users can navigate to the login page from both the virtual bank home page
  and the registration page
- Wallet helper interactions now visually focus attention using a dimmed background