### PR TITLE
feat: implement interactive bank PIN pad behaviour

### DIFF
--- a/bankSetup/bank-choices.html
+++ b/bankSetup/bank-choices.html
@@ -44,13 +44,16 @@
     <main>
 
         <section id="choose-bank" class="mt-48 mb-48">
-            <div class="choose-bank__container">
+            
+            <div class="choose-bank__container account-setup">
                 <div class="bank-status mb-24">
                     <small>Step 2 of 4</small>
                     <h1 class="capitalise light-bold">Select your bank</h1>
                     <p>Choose from a list of banks</p>
                 </div>
-                <form action="" method="post" id="chooose-bank-form">
+
+                <form action="" method="post" id="chooose-bank-form" role="form">
+
                     <div class="choose-bank__cards flex-grid three-column-grid">
 
                         <!-- card 1 -->
@@ -264,7 +267,8 @@
                             <p>Can’t find your bank? No problem, you can choose a different one.</p>
 
                         </div>
-                        <button type="submit" class="btn-medium" id="bank-btn-continue">Continue</button>
+                        <a href="/bankSetup/bank-pin-setup.html" class="btn-medium bank-btn-continue capitalise">Continue</a>
+                        
                     </div>
                 </form>
             </div>

--- a/bankSetup/bank-pin-setup.html
+++ b/bankSetup/bank-pin-setup.html
@@ -58,49 +58,62 @@
 
                 </div>
 
-               <form action="" id="bank-pin-form" role="form">
-                
-                <h1 class="capitalise center header-6 light-bold">Set your 6 digit PIN</h1>
-                <p class="center mb-16 text-muted">Create a secure 6-digit PIN to approve bank transactions </p>
+                <form action="" id="bank-pin-form" role="form">
 
-                  <div class="pin-wrapper flex-grid six-column-grid">
-                    <input type="text" name="first_pin"  id="first-pin"  inputmode="numeric" maxlength="1" class="pin-number" disabled>
-                    <input type="text" name="second_pin" id="second-pin" inputmode="numeric" maxlength="1" class="pin-number" disabled>
-                    <input type="text" name="third_pin"  id="third-pin"  inputmode="numeric" maxlength="1" class="pin-number" disabled>
-                    <input type="text" name="fourth_pin" id="fourth-pin" inputmode="numeric" maxlength="1" class="pin-number" disabled>
-                    <input type="text" name="fifth_pin"  id="fifth-pin"  inputmode="numeric" maxlength="1" class="pin-number" disabled>
-                    <input type="text" name="six_pin"    id="six-pin"    inputmode="numeric" maxlength="1" class="pin-number" disabled>
-                </div>
+                    <h1 class="capitalise center header-6 light-bold">Set your 6 digit PIN</h1>
+                    <p class="center mb-16 text-muted">Create a secure 6-digit PIN to approve bank transactions </p>
 
-                <div id="pin-selection" class="mt-24">
+                    <!-- Hidden input for actual pin value (for screen readers + form) -->
+                    <label for="pin-hidden" class="sr-only">Enter 6 digit PIN</label>
+                    <input id="pin-hidden" type="text" inputmode="numeric" maxlength="6" pattern="[0-9]*"
+                        autocomplete="one-time-code" class="sr-only" aria-describedby="pin-status pin-error">
 
-                    <div class="pin-selector__container flex-grid three-column-grid">
-                           <div class="pin-selection__number"  data-number="1">1</div>
-                            <div class="pin-selection__number" data-number="2">2</div>
-                            <div class="pin-selection__number" data-number="3">3</div>
-                            <div class="pin-selection__number" data-number="4">4</div>
-                            <div class="pin-selection__number" data-number="5">5</div>
-                            <div class="pin-selection__number" data-number="6">6</div>
-                            <div class="pin-selection__number" data-number="7">7</div>
-                            <div class="pin-selection__number" data-number="8">8</div>
-                            <div class="pin-selection__number" data-number="9">9</div>
+                     <!-- Visual PIN display -->
+                    <div class="pin-wrapper flex-grid six-column-grid">
+                        <input type="text" name="first_pin" id="first-pin" inputmode="numeric" maxlength="1" class="pin-number" readonly >
+                        <input type="text" name="second_pin" id="second-pin" inputmode="numeric" maxlength="1" class="pin-number" readonly >
+                        <input type="text" name="third_pin" id="third-pin" inputmode="numeric" maxlength="1" class="pin-number" readonly>
+                        <input type="text" name="fourth_pin" id="fourth-pin" inputmode="numeric" maxlength="1" class="pin-number" readonly>
+                        <input type="text" name="fifth_pin" id="fifth-pin" inputmode="numeric" maxlength="1" class="pin-number" readonly >
+                        <input type="text" name="six_pin" id="six-pin" inputmode="numeric" maxlength="1"  class="pin-number" readonly>
                     </div>
 
-                    <div class="pin-keypad__actions flex-grid two-column-grid mt-8">
-                         <div class="pin-selection__number" data-number="0">0</div>
-                         <div class="pin-selection__number" data-number=""><i class="fa-solid fa-delete-left"></i></div>
+                    <!-- Number pad -->
+                    <div id="pin-selection" class="mt-24">
+
+                        <div class="pin-selector__container flex-grid three-column-grid" aria-label="PIN digits">
+                            <div class="pin-pad-btn" data-number="1">1</div>
+                            <div class="pin-pad-btn" data-number="2">2</div>
+                            <div class="pin-pad-btn" data-number="3">3</div>
+                            <div class="pin-pad-btn" data-number="4">4</div>
+                            <div class="pin-pad-btn" data-number="5">5</div>
+                            <div class="pin-pad-btn" data-number="6">6</div>
+                            <div class="pin-pad-btn" data-number="7">7</div>
+                            <div class="pin-pad-btn" data-number="8">8</div>
+                            <div class="pin-pad-btn" data-number="9">9</div>
+                        </div>
+
+                        <div class="pin-keypad__actions flex-grid two-column-grid mt-8">
+                            <div class="pin-pad-btn" data-number="0">0</div>
+                            <div class="pin-pad-btn" data-number="backspace"><i class="fa-solid fa-delete-left"></i>
+                            </div>
+                        </div>
+
                     </div>
+                </form>
+
+
+                <div class="choose-bank__btns flex flex-end mt-8">
+                    <a href="/bankSetup/bank-choices.html"
+                        class="capitalise btn-medium mr-24 bank-btn-back center capitalise" aria-label="Go back to bank choices">
+                        back</a>
+                    
+                     <button type="submit" class="btn-medium bank-btn-continue capitalise">
+                        Continue
+                    </button>
 
                 </div>
 
-               </form>
-
-                 <div class="choose-bank__btns flex flex-end mt-8">
-                        <a href="/bankSetup/bank-choices.html" class="capitalise btn-medium mr-24 bank-btn-back center capitalise" aria-label="button"> back</a>
-                        <a href="" class="btn-medium bank-btn-continue capitalise" aria-label="button">Continue</a>
-                     
-                </div>
-                
             </div>
         </section>
 
@@ -109,7 +122,7 @@
 
     </main>
 
-    <script src="/static/js/bankSetup/bankSetup.js" type="module"></script>
+    <script src="/static/js/bankSetup/bankPinSetup.js" type="module"></script>
 </body>
 
 </html>

--- a/bankSetup/bank-pin-setup.html
+++ b/bankSetup/bank-pin-setup.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="/static/css/style.css">
+    <link rel="shortcut icon" href="/static/images/virtual-bank-logo.png" type="image/x-icon">
+    <link rel="stylesheet" href="/static/vendor/fontawesome/css/all.min.css">
+    <title>Bank pin setup</title>
+</head>
+
+<body>
+
+    <header class="mb-16">
+        <nav aria-label="Main navigation" id="bank-pin-navbar">
+            <div class="nav-container flex-grid two-column-grid">
+
+                <!-- Logo / Home -->
+                <div class="head">
+                    <a href="/" class="nav-link pt-8 bold" id="virtual-bank-logo">
+                        <img src="/static/images/virtual-bank-logo.png" alt="Virtual Bank home" class="logo" />
+                    </a>
+                </div>
+
+                <!-- Navigation Links -->
+                <div class="body flex flex-end">
+                    <ul class="flex-grid two-column-grid" role="list">
+
+
+                        <li>
+                            <a href="/vritual-bank-register.html" class="nav-link light-bold capitalise"
+                                id="nav-security">
+                                Hi, User
+                            </a>
+                        </li>
+
+                    </ul>
+                </div>
+
+            </div>
+        </nav>
+    </header>
+
+    <main>
+
+        <section id="bank-pin-setup" class="mt-48 mb-48">
+            <div class="bank-pin-setup__container account-setup">
+                <div class="bank-status mb-24">
+                    <small>Step 3 of 4</small>
+                    <h1 class="capitalise light-bold">Set your pin</h1>
+                    <p>Create a secure 6-digit PIN to approve bank transactions</p>
+
+                    <hr class="dividor">
+                    <p class="">This will keep your account secure. Don't share your PIN with anyone
+                        and try not to set it as something as easy to guess like 123456
+                    </p>
+
+                </div>
+
+               <form action="" id="bank-pin-form" role="form">
+                
+                <h1 class="capitalise center header-6 light-bold">Set your 6 digit PIN</h1>
+                <p class="center mb-16 text-muted">Create a secure 6-digit PIN to approve bank transactions </p>
+
+                  <div class="pin-wrapper flex-grid six-column-grid">
+                    <input type="text" name="first_pin"  id="first-pin"  inputmode="numeric" maxlength="1" class="pin-number" disabled>
+                    <input type="text" name="second_pin" id="second-pin" inputmode="numeric" maxlength="1" class="pin-number" disabled>
+                    <input type="text" name="third_pin"  id="third-pin"  inputmode="numeric" maxlength="1" class="pin-number" disabled>
+                    <input type="text" name="fourth_pin" id="fourth-pin" inputmode="numeric" maxlength="1" class="pin-number" disabled>
+                    <input type="text" name="fifth_pin"  id="fifth-pin"  inputmode="numeric" maxlength="1" class="pin-number" disabled>
+                    <input type="text" name="six_pin"    id="six-pin"    inputmode="numeric" maxlength="1" class="pin-number" disabled>
+                </div>
+
+                <div id="pin-selection" class="mt-24">
+
+                    <div class="pin-selector__container flex-grid three-column-grid">
+                           <div class="pin-selection__number"  data-number="1">1</div>
+                            <div class="pin-selection__number" data-number="2">2</div>
+                            <div class="pin-selection__number" data-number="3">3</div>
+                            <div class="pin-selection__number" data-number="4">4</div>
+                            <div class="pin-selection__number" data-number="5">5</div>
+                            <div class="pin-selection__number" data-number="6">6</div>
+                            <div class="pin-selection__number" data-number="7">7</div>
+                            <div class="pin-selection__number" data-number="8">8</div>
+                            <div class="pin-selection__number" data-number="9">9</div>
+                    </div>
+
+                    <div class="pin-keypad__actions flex-grid two-column-grid mt-8">
+                         <div class="pin-selection__number" data-number="0">0</div>
+                         <div class="pin-selection__number" data-number=""><i class="fa-solid fa-delete-left"></i></div>
+                    </div>
+
+                </div>
+
+               </form>
+
+                 <div class="choose-bank__btns flex flex-end mt-8">
+                        <a href="/bankSetup/bank-choices.html" class="capitalise btn-medium mr-24 bank-btn-back center capitalise" aria-label="button"> back</a>
+                        <a href="" class="btn-medium bank-btn-continue capitalise" aria-label="button">Continue</a>
+                     
+                </div>
+                
+            </div>
+        </section>
+
+
+
+
+    </main>
+
+    <script src="/static/js/bankSetup/bankSetup.js" type="module"></script>
+</body>
+
+</html>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1560,15 +1560,27 @@ label {
 .pin-number {
     text-align: center;
     align-items: center;
-    height: 30px;
+    height: 50px;
     font-weight: bold;
+    background: #FFFFFF;
+    border: 1px solid #C9D3E1;
+    border-radius: 8px;
+    font-size: 2rem;
+    -webkit-text-security: disc;
+    text-security: disc;
+}
+
+.pin-number.filled {
+    background: #E9EEF6;
+    border: 1px solid #C9D3E1;
+    color: #1F2937;
 }
 
 .pin-wrapper {
     column-gap: var(--space-16);
 }
 
-.pin-selection__number {
+.pin-pad-btn {
     text-align: center;
     border: 1px solid lavender;
     background: #f8fafc;   /* very light grey / off-white */
@@ -1580,7 +1592,13 @@ label {
   
 }
 
-.pin-selection__number:hover {
+.pin-pad-btn.clicked {
+    transform: scale(0.8);
+    border: 1px solid #C9D3E1;
+}
+
+
+.pin-pad-btn:hover {
     background: ghostwhite;
 }
 
@@ -1614,4 +1632,11 @@ label {
 
 .bank-btn-back:hover {
     background: #d1d5db;
+}
+
+
+
+.pin-number:focus {
+  border-color: #1E4FD7;
+  box-shadow: 0 0 0 3px rgba(30, 79, 215, 0.15);
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -456,6 +456,11 @@ img:hover {
     grid-template-rows: auto;
 }
 
+.six-column-grid {
+    grid-template-columns: repeat(6, 1fr);
+     grid-template-rows: auto;
+}
+
 
 .two-column-40_60_grid {
     grid-template-columns: 40% 60%;
@@ -757,9 +762,11 @@ button {
 
 
 .btn-medium {
-    width: 15%;
+    width: 10%;
     padding: var(--space-8);
 }
+
+
 /* The main images */
 #main-image {
     position: absolute;
@@ -1388,8 +1395,7 @@ label {
 
 
 /* bank setup page attributes */
-
-.choose-bank__container{
+.account-setup {
     background-image: url("/static/images/background-3.png");
     background-repeat: no-repeat;
     background-position: center;
@@ -1399,10 +1405,6 @@ label {
 }
 
 
-#choose-bank-navbar {
-    width: 91%;
-    margin: auto;
-}
 
 #bank-choices-header__container__head {
     position: relative;
@@ -1417,12 +1419,15 @@ label {
     width: 100%;
 }
 
-
+/* bank and pin elemnts */
+#bank-pin-navbar,
+.bank-pin-setup__container,
 #choose-bank-navbar,
 .choose-bank__container {
     width: 91%;
     margin: auto;
 }
+
 
 .choose-bank__container {
     border: 2px solid lavender;
@@ -1513,15 +1518,17 @@ label {
 
 
 
-#bank-btn-continue {
+.bank-btn-continue {
     background: var(--blue-600);
     color: white;
-    font-weight: 600;
+    font-weight: 500;
     cursor: pointer;
     box-shadow: var(--box-shadow-secondary);
+    text-align: center;
+    /* font-size: 0.95rem; */
 }
 
-#bank-btn-continue:hover {
+.bank-btn-continue:hover {
     background: white;
     color: black;
     border: 4px solid lavender;
@@ -1545,4 +1552,66 @@ label {
   .choose-bank__card {
     transition: none;
   }
+}
+
+
+/* The pin section elements */
+
+.pin-number {
+    text-align: center;
+    align-items: center;
+    height: 30px;
+    font-weight: bold;
+}
+
+.pin-wrapper {
+    column-gap: var(--space-16);
+}
+
+.pin-selection__number {
+    text-align: center;
+    border: 1px solid lavender;
+    background: #f8fafc;   /* very light grey / off-white */
+    color: #0f172a;
+
+    padding: var(--space-8);
+    cursor: pointer;
+    font-weight: 500;
+  
+}
+
+.pin-selection__number:hover {
+    background: ghostwhite;
+}
+
+.pin-selector__container {
+    column-gap: var(--space-8);
+    row-gap: var(--space-8);
+}
+
+#bank-pin-form {
+    width: 55%;
+    margin: auto;
+    background: white;
+    padding: 50px;
+    box-shadow: var(--box-shadow-primary);
+}
+
+.bank-pin-setup__container {
+    padding: var(--space-48);
+}
+
+.pin-keypad__actions {
+    column-gap: var(--space-8);
+    font-weight: 500;
+}
+
+.bank-btn-back {
+    background: #e5e7eb;
+    color: #374151;
+    font-weight: 600;
+}
+
+.bank-btn-back:hover {
+    background: #d1d5db;
 }

--- a/static/js/bankSetup/bankPinSetup.js
+++ b/static/js/bankSetup/bankPinSetup.js
@@ -1,0 +1,142 @@
+const bankPinForm           = document.getElementById("bank-pin-form")
+const inputPinFieldsElements = document.querySelectorAll(".pin-number")
+
+
+// TODO
+// Add one time check for bank form element exist before running
+
+
+bankPinForm.addEventListener("click", handleDelegation)
+
+
+
+/**
+ * Handles click events on the PIN pad buttons.
+ *
+ * Depending on the button pressed, this function either:
+ *   - adds a number to the PIN input field, or
+ *   - removes the last number when the backspace button is pressed.
+ * *
+ * @param {Event} e - The click event from the PIN pad button.
+ */
+function handleDelegation(e) {
+    const pinPadBtn = e.target;
+    const number    = pinPadBtn.dataset.number;
+
+    if (number && number !== "backspace") {
+         addDigitToNextEmptyPinField(number)
+         handlePinPadClick(pinPadBtn);
+    } else if (number === "backspace"){
+         removeLastDigitFromPin();
+         handlePinPadClick(pinPadBtn);
+    }
+   
+}
+
+
+
+/**
+ * Inserts a single digit into the next empty PIN input field
+ * (left to right), updates its background state, and focuses it.
+ * Does not overwrite existing values.
+ *
+ * @param {string|number} digit - The digit to add to the PIN.
+ */
+function addDigitToNextEmptyPinField(number) {
+
+    for (let i = 0; i < inputPinFieldsElements.length; i++) {
+        const inputPinFieldElement = inputPinFieldsElements[i]
+        if (!inputPinFieldElement.value) {
+
+            inputPinFieldElement.value = number;
+            togglePinInputFieldBackgroundState(inputPinFieldElement)
+            inputPinFieldElement.focus()
+            return;
+        }
+      
+    }
+   
+}
+
+
+/**
+ * Removes the last entered digit from the PIN input fields (right to left).
+ * Clears the field, updates its background state, and moves focus to the
+ * previous input field.
+ *
+ * If no digits are present, the function exits early.
+ */
+function removeLastDigitFromPin() {
+
+    for (let i = inputPinFieldsElements.length - 1; i >= 0; i--) {
+
+        const inputPinFieldElement = inputPinFieldsElements[i];
+       
+        if (inputPinFieldElement.value ) {
+            inputPinFieldElement.value = "";
+
+            addFocusToPreviousPinInputField(i);
+            togglePinInputFieldBackgroundState(inputPinFieldElement, false)
+            return;
+        }
+      
+    }
+}
+
+
+/**
+ * Moves focus to the previous PIN input field.
+ * @param {number} currentPinNumberField - The index of the currently active PIN input field.
+ */
+function addFocusToPreviousPinInputField(currentPinNumberField) {
+    const previousPinNumberField = currentPinNumberField - 1;
+    if (previousPinNumberField >= 0) {
+        inputPinFieldsElements[previousPinNumberField].focus();
+    }
+    return;
+}
+
+
+
+
+/**
+ * Adds a temporary visual click effect to a PIN pad button.
+ *
+ * The function adds a CSS class to the button element to create a visual
+ * feedback effect that simulates a click
+ *
+ * @param {HTMLElement} pinPadBtn - The button element that was clicked.
+ */
+function handlePinPadClick(pinPadBtn) {
+    const MILLISECONDS = 200;
+    const cssSelector = "clicked";
+
+    pinPadBtn.classList.add(cssSelector);
+   
+    setTimeout(() => {
+        pinPadBtn.classList.remove(cssSelector)
+    }, MILLISECONDS)
+
+
+}
+
+
+/**
+ * Toggles the background state of a PIN input field.
+ *
+ * Adds or removes a CSS class to visually indicate whether the field is
+ * filled/active. By default, the function activates the field unless
+ * explicitly set to false.
+ *
+ * @param {HTMLElement} pinInputField - The PIN input field element.
+ * @param {boolean} [isActive=true] - Whether to activate (true) or deactivate (false) the field.
+ */
+function togglePinInputFieldBackgroundState(pinInputField, isActive = true) {
+    const cssSelector = "filled";
+
+    if (isActive){
+        pinInputField.classList.add(cssSelector);
+        return
+    }
+     pinInputField.classList.remove(cssSelector);
+}


### PR DESCRIPTION
### Goal

The goal of this commit is to allow users to enter a bank PIN using the on-screen PIN pad.  
Clicking a number updates the PIN input fields and visually indicates it as a filled fields.  
Users can also remove digits using the backspace button which also removes the filled field.

### Changes Included

- Created a `bankPinSetup.js` file in the `bankSetup` folder and linked it to the `bank-pin-setup.html` file
- Implemented PIN pad click handling using event delegation
- Added logic to insert numbers into the next available PIN input field
- Added support for removing the last entered digit via the backspace button
- Updated PIN input field background state when digits are added or removed
- Managed focus movement between PIN input fields
- Added visual feedback for PIN pad button clicks
- Added the CSS to make the field display in dots but still store the number as a digit but hidden

### Notes

- PIN input remains fully controlled via JavaScript via `bankPinSetup.js` file
- Only numeric input is supported through the on-screen PIN pad
- PIN validation and submission will be handled in a later commit
