### PR TITLE
The goal of this commit is to improve PIN entry security by visually cloaking digits as the user types.

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1566,9 +1566,17 @@ label {
     border: 1px solid #C9D3E1;
     border-radius: 8px;
     font-size: 2rem;
+   
+}
+
+
+
+.pin-number.cloak {
     -webkit-text-security: disc;
     text-security: disc;
 }
+
+
 
 .pin-number.filled {
     background: #E9EEF6;

--- a/static/js/bankSetup/bankPinSetup.js
+++ b/static/js/bankSetup/bankPinSetup.js
@@ -46,16 +46,44 @@ function addDigitToNextEmptyPinField(number) {
 
     for (let i = 0; i < inputPinFieldsElements.length; i++) {
         const inputPinFieldElement = inputPinFieldsElements[i]
-        if (!inputPinFieldElement.value) {
 
+        if (!inputPinFieldElement.value) {
             inputPinFieldElement.value = number;
-            togglePinInputFieldBackgroundState(inputPinFieldElement)
-            inputPinFieldElement.focus()
+            inputPinFieldElement.focus();
+            togglePinInputFieldBackgroundState(inputPinFieldElement);
+            cloakPreviousDigit(i);
             return;
         }
       
     }
    
+}
+
+
+
+/**
+ * Cloaks the previous digit with a disc.
+ * The first digit is visible initially, but once the user
+ * enters the next digit, the previous one is cloaked.
+ *
+ * Note: the last digit has no following digit, so it is
+ * cloaked immediately.
+ */
+function cloakPreviousDigit(currentPinIndex) {
+  const previousIndex = currentPinIndex - 1;
+  const lastIndex     = inputPinFieldsElements.length -1;
+
+  
+  if (previousIndex >= 0) {
+    inputPinFieldsElements[previousIndex].classList.add("cloak")
+  } 
+  
+  if (lastIndex === currentPinIndex) {
+    inputPinFieldsElements[currentPinIndex].classList.add("cloak")
+  }
+
+
+
 }
 
 
@@ -74,6 +102,7 @@ function removeLastDigitFromPin() {
        
         if (inputPinFieldElement.value ) {
             inputPinFieldElement.value = "";
+            inputPinFieldElement.classList.remove("cloak")
 
             addFocusToPreviousPinInputField(i);
             togglePinInputFieldBackgroundState(inputPinFieldElement, false)


### PR DESCRIPTION
When a new digit is entered, the previous digit is replaced with a cloaked (disc) state. The final digit is automatically cloaked since it has no following digit.

- Added logic to cloak the previously entered PIN digit when a new digit is entered
- Ensured the first PIN digit remains visible until a second digit is entered
- Automatically cloaked the final PIN digit once entered
- Introduced a reusable `cloakPreviousDigit` helper function for clarity
- Applied a `cloak` CSS class to control visual masking behaviour

- Cloaking behaviour is handled entirely via JavaScript
- The actual PIN digits are preserved internally while being visually masked
- This change focuses purely on UX and security feedback, not validation or submission
- PIN validation logic will be handled in a later commit