### PR TITLE
feat(wallet): add wallet confirmation in Step 3 and fix input delegation bug

### DIFF
--- a/bank/dashboard.html
+++ b/bank/dashboard.html
@@ -618,7 +618,7 @@
                                     <div id="wallet-option__three-form" class="mt-16" role="group"
                                         aria-labelledby="wallet-option-manual">
 
-                                        <form action="" method="post">
+                                        <form action="" method="post" id="link-wallet-form">
 
                                             <div class=" mt-8 mb-24">
                                                 <input type="checkbox" name="verify-wallet" id="verify-wallet-checkbox"
@@ -672,6 +672,8 @@
                         </div>
 
                         <section id="connect-with-wallet-id">
+
+                             <a href="#" id="wallet-modal-connect-back-anchor" class="mb-8">&lt; back</a>
 
                             <div id="connect-with-wallet-id__container">
                                 <h1 class="center header-6">Connect with wallet ID</h1>
@@ -758,9 +760,9 @@
                                 <div id="wallet-auth-completion" class="center mt-8 hide">
                                         <p id="wallet-connect-msg" class="mt-8">Your wallet has successfully been
                                         connected to your bank account, you can now close the page and proceed to step 3</p>
-                                    <button id="auth-wallet__cancel-btn" class="btn-semi-medium cancel-btn mt-8" type="button"
+                                    <button id="auth-wallet__cancel-btn" class="btn-semi-medium mt-8 blue-bg white-text" type="button"
                                         data-action="cancel">
-                                        Cancel
+                                        Close
                                     </button>
                                 </div>
                                
@@ -865,7 +867,7 @@
         </section>
 
     </main>
-
+     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11.12.2/dist/sweetalert2.all.min.js"></script>
     <script src="/static/js/dashboard/bank-dashboard.js" type="module"></script>
 </body>
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2290,6 +2290,11 @@ time {
 
 }
 
+#connect-with-wallet-id.show {
+    display: grid;
+  
+}
+
 
 #connect-wallet-modal h2 {
     font-weight: 500;

--- a/static/js/dashboard/bank-dashboard.js
+++ b/static/js/dashboard/bank-dashboard.js
@@ -1,4 +1,5 @@
 import { sanitizeText } from "../utils.js";
+import { AlertUtils } from "../alerts.js";
 
 
 const dashboardProfileElement = document.getElementById("dashboard-profile");
@@ -15,6 +16,7 @@ const walletAuthInputFieldPanel = document.getElementById("connect-with-wallet-i
 const progressElement = document.getElementById("walletProgress");
 const progressValue = document.getElementById("walletProgressValue");
 const walletAuthForm = document.getElementById("connect-wallet-form");
+const linkAccountForm = document.getElementById("link-wallet-form");
 let walletModalStep2Button;
 
 
@@ -31,7 +33,8 @@ walletAuthForm.addEventListener("submit", handleWalletAuthForm);
 
 
 
-console.log(connectWalletModal)
+
+
 
 function handleDropDownMenu(e) {
     const profileImg = e.target.closest("img");
@@ -40,14 +43,6 @@ function handleDropDownMenu(e) {
     }
 }
 
-
-
-function handleDelegation(e) {
-
-    WalletWizard.handleWalletConnectionSteps(e)
-
-
-}
 
 
 
@@ -71,7 +66,7 @@ const WalletWizard = (() => {
     }
 
     function closeWalletAuthPanel() {
-        walletAuthInputFieldPanel.style.display = "none";
+        toggleElement({element: walletAuthInputFieldPanel, show: false})
 
 
     }
@@ -102,9 +97,11 @@ const WalletWizard = (() => {
     }
 
     function selectWalletIdConnect(e) {
-        console.log("clicked")
-        disableStep2Button();
-        WalletWizard.handleWalletConnectAuthInputFields(e)
+        
+            disableStep2Button();
+            WalletWizard.handleWalletConnectAuthInputFields(e)
+        
+        
     }
 
 
@@ -165,6 +162,8 @@ const WalletWizard = (() => {
         },
 
         handleWalletConnectAuthInputFields(e, deleteMode = false) {
+
+            
             openWalletAuthInputPanel();
 
             walletOptionAuthInputFields[0]?.focus()
@@ -195,12 +194,17 @@ const WalletWizard = (() => {
                     walletOptionAuthInputFields[currentIndex].value = "";
                 }
 
+                if (currentIndex === lastIndex && !deleteMode) {
+                  walletOptionAuthInputFields[currentIndex].focus();   
+                }
+
 
             }
         },
         handleWalletConnectionSteps(e) {
             const elementID = e.target.id;
 
+           
             if (elementID === "modal-close-btn") {
                 WalletWizard.closeModal();
                 return;
@@ -234,6 +238,11 @@ const WalletWizard = (() => {
                 case "wallet-modal-previous-step1":
                     WalletWizard.previousStep(1);
                     break;
+                case "wallet-modal-connect-back-anchor":
+                    enableStep2Button();
+                    closeWalletAuthPanel()
+                    WalletWizard.previousStep(2);
+                    break;
 
 
             }
@@ -256,6 +265,8 @@ function toggleElement({ element, cSSSelector = "show", show = true }) {
 
 
 dashboard.addEventListener("input", (e) => {
+
+    if (e && e.target.type === "checkbox") return;
     WalletWizard.handleWalletConnectAuthInputFields(e);
 });
 
@@ -263,6 +274,18 @@ dashboard.addEventListener("input", (e) => {
 dashboard.addEventListener("keydown", (e) => {
     WalletWizard.handleBackspaceOrDelete(e);
 });
+
+linkAccountForm.addEventListener("submit", handleWalletLinkFormSubmission)
+
+function handleDelegation(e) {
+ 
+
+    WalletWizard.handleWalletConnectionSteps(e)
+
+
+}
+
+
 
 
 
@@ -341,5 +364,30 @@ function showWalletAuthCompletionMsg() {
  */
 function removeAuthWalletVerifyBtn() {
     const btn = document.getElementById("auth-verify-btn");
-    toggleElement({ element: btn, cSSSelector: "hide", show: false });
+    btn.style.display = "none";
+}
+
+
+
+/**
+ * Handles the form link confirmation form, the final step before
+ * a wallet is linked to the bank account.
+ */
+async function handleWalletLinkFormSubmission(e) {
+    e.preventDefault();
+
+    const confirmed = await AlertUtils.showConfirmationAlert({
+        title: "Link wallet to bank account?",
+        text: "This will securely link your wallet so funds can move between accounts.",
+        confirmButtonText: "Link account",
+        messageToDisplayOnSuccess: "The accounts have been linked",
+        denyButtonText: "Cancel",
+        cancelMessage: "Wallet linking cancelled."
+    });
+
+   if (confirmed) {
+    WalletWizard.closeModal();
+   }
+
+ 
 }


### PR DESCRIPTION
## feat(wallet): add wallet confirmation in Step 3 and fix input delegation bug
feat(wallet): add wallet confirmation in Step 3 and fix input delegation bug


## Goal

This commit introduces a confirmation alert requiring the user to explicitly confirm before a wallet is linked to their bank account.
It also fixes a bug where clicking the checkbox **"I authorise Virtual Bank to link this wallet"** unintentionally opened the wallet authentication ID panel.


## Bug Fixes

The issue occurred because the dashboard input delegation listener was listening to all input events, including checkbox inputs.

The delegation calls:

`WalletWizard.handleWalletConnectAuthInputFields(e)`

which opens the wallet authentication ID panel and executes wallet ID handling logic.

Since a checkbox is also considered an input field, clicking it triggered the same handler which caused the authentication panel to open whenever the checkbox was clicked in Step 3.
The updated solution first checks if the input is not a checkbox before proceeding.

### Previous behaviour
```js
dashboard.addEventListener("input", (e) => {
    WalletWizard.handleWalletConnectAuthInputFields(e);
});
````

### Updated solution

Checkbox inputs are now ignored:

```js
dashboard.addEventListener("input", (e) => {
    if (e && e.target.type === "checkbox") return;
    WalletWizard.handleWalletConnectAuthInputFields(e);
});
```

This prevents unintended panel activation when interacting with checkboxes.

## Changes

* Added confirmation dialog requiring user approval before wallet linking.
* Added necessary JS logic to support confirmation flow.
* Prevented authentication panel from opening when checkbox inputs are clicked.
* Removed verify button after successful 12-digit wallet ID entry.

## Usage Notes

Users can now select **Connect with wallet ID** in Step 2 and enter their 12-digit wallet ID.

Authentication progress remains simulated on the frontend, and no backend verification occurs yet.

In a future update, submission behaviour will call the backend verification endpoint via `fetch`.

## Workflow

* User clicks **Connect wallet**.
* User selects **Connect with wallet ID** in Step 2.
* Wallet ID entry panel opens.
* User enters the 12-digit wallet ID.
* User checks the authorization checkbox.
* User submits verification.
* Confirmation dialog appears.
* User confirms or cancels linking.
* On confirmation, the dialog closes and linking proceeds.

## TODO (future updates)

* Implement backend verification using `fetch`.
* Connect progress indicator to real authentication responses.
* Handle validation errors and retry flows.
* Add loading and error states.
* Add keyboard navigation and paste handling for wallet ID inputs.
* Improve accessibility and mobile layout refinements.

## Notes

* Responsiveness improvements will follow in a later UI polish pass.
* Backend integration will be added once the verification endpoint becomes available.
* As with other pages, responsiveness is not yet implemented and will be addressed later.
There is also no logic that verifies that user has executed either one of the options in step 2, this means a user can run step 3 without running the options in step 2. However, this will be handled in the backend not the fronted at a later date.