### PR TITLE
feat(wallet): add wallet disconnection confirmation modal

### DIFF
--- a/bank/dashboard.html
+++ b/bank/dashboard.html
@@ -366,7 +366,7 @@
                                                     <a href="#" class="btn-large capitalize center bank-dashboard-btn"
                                                         id="connect-wallet-btn">Connect Wallet</a>
                                                     <a href="#" class="btn-large capitalize center bank-dashboard-btn"
-                                                        id="disconnect-wallet">Status</a>
+                                                        id="disconnect-wallet-status">Status</a>
                                                 </div>
 
                                             </div>
@@ -393,7 +393,7 @@
 
                         <div class="flex flex-space-between pl-24 pt-8 pb-4 pr-24 modal-top">
                             <h2 id="connect-wallet-title" class="capitalise">Link new wallet</h2>
-                            <button aria-label="Close modal" class="modal-close-btn" id="modal-close-btn">
+                            <button aria-label="Close modal" class="modal-close-btn" id="connect-modal-close-btn">
                                 ✕
                             </button>
                         </div>
@@ -854,10 +854,12 @@
                             Manage account
                         </h2>
 
-                        <button aria-label="Close manage account dialog" class="modal-close-btn" id="modal-close-btn"
+                        <button aria-label="Close manage account dialog" class="modal-close-btn" id="dashboard-status-modal-close-btn"
                             type="button">
-                            <span aria-hidden="true">✕</span>
+                            <span aria-hidden="true" id="">✕</span>
                         </button>
+
+                        
                     </div>
 
                     <div id="status__container" class="pt-8">
@@ -962,12 +964,14 @@
                                     <div class="connection__actions flex-grid two-column-grid">
 
                                         <button type="button"
+                                           id="refresh-connection-btn"
                                             class="connection__button btn-large blue-bg white-text js-refresh-connection">
                                             <i class="fa-solid fa-arrows-rotate" aria-hidden="true"></i>
                                             Refresh connection
                                         </button>
 
                                         <button type="button"
+                                            id="test-connection-btn"
                                             class="connection__button btn-large green-bg white-text js-test-connection">
                                             <i class="fa-solid fa-plug" aria-hidden="true"></i>
                                             Test connection
@@ -1026,6 +1030,7 @@
 
                             <div class="connection__actions">
                                 <button type="button"
+                                   id="disconnect-btn"
                                     class="connection__button btn-large white-text disconnect-btn capitalise"
                                     aria-describedby="disconnect-title">
                                     <i class="fa-solid fa-xmark" aria-hidden="true"></i>
@@ -1049,7 +1054,7 @@
                         </h2>
 
                         <button aria-label="Close disconnect confirmation dialog" class="modal-close-btn"
-                            id="modal-close-btn" type="button">
+                            id="disconnection-modal-close-btn" type="button">
                             <span aria-hidden="true">✕</span>
                         </button>
                     </div>
@@ -1066,7 +1071,7 @@
                             <div class="disconnection-description">
 
                                 <h3 id="wallet-disconnect-title" class="header-9 disconnect-heading light-bold">
-                                    Are you sure you want to disconnect this external bank account?
+                                    Are you sure you want to disconnect this wallet from your external bank account?
                                 </h3>
 
                             </div>
@@ -1099,14 +1104,14 @@
                                     Type DISCONNECT to confirm bank disconnection
                                 </label>
 
-                                <form action="" method="post">
-                                      <input type="text" name="wallet-disconnect" id="wallet-disconnect" maxlength="10"
-                                       minlength="10" aria-describedby="disconnect-confirm-instruction" autocomplete="off" required>
+                                <input type="text" name="wallet-disconnect" id="wallet-disconnect-inputfield" maxlength="10"
+                                    minlength="10" aria-describedby="disconnect-confirm-instruction" autocomplete="off"
+                                    required>
 
-                                       
-                                </form>
 
-                              
+
+
+
                             </div>
 
                         </div>
@@ -1115,11 +1120,11 @@
                     <!-- Footer -->
                     <div id="wallet-disconnection-confirmation__footer" class="flex flex-end mr-16 mb-24">
 
-                        <button type="button" class="cancel-disconnect-btn mr-8">
+                        <button type="button" class="mr-8" id="cancel-disconnect-btn">
                             Cancel
                         </button>
 
-                        <button type="submit" class="confirm-disconnect-btn">
+                        <button type="button" id="confirm-disconnect-btn">
                             Disconnect account
                         </button>
 

--- a/bank/dashboard.html
+++ b/bank/dashboard.html
@@ -532,7 +532,8 @@
 
                                         <div class="wallet-option__one_confirmation mr-8 mt-16">
 
-                                            <button class="blue-bg white-text center btn-large wallet-option-btn" id="select-manual-connection">
+                                            <button class="blue-bg white-text center btn-large wallet-option-btn"
+                                                id="select-manual-connection">
                                                 Select manual connection
                                             </button>
 
@@ -794,7 +795,7 @@
                                     Your wallet credentials is invalid. Please try again.
                                 </div>
 
-                                  
+
 
                                 <form action="" method="post" id="manually-verification-wallet-form"
                                     aria-labelledby="wallet-form-title">
@@ -818,13 +819,15 @@
                                     <div class="flex-row flex-grid">
                                         <label for="password">Password</label>
                                         <input type="password" name="password" id="password" required
-                                            aria-required="true" aria-describedby="password-note" maxlength="40" minlength="8">
+                                            aria-required="true" aria-describedby="password-note" maxlength="40"
+                                            minlength="8">
                                         <small id="password-note" class="sr-only">Enter your wallet password
                                             securely</small>
                                     </div>
 
                                     <div class="buttons mt-16 mb-16">
-                                        <button type="submit" class="btn-large blue-bg white-text capitalise" id="manually-wallet-link-btn">
+                                        <button type="submit" class="btn-large blue-bg white-text capitalise"
+                                            id="manually-wallet-link-btn">
                                             verify Wallet credentials!
                                         </button>
                                     </div>
@@ -840,47 +843,200 @@
 
                         </section>
 
-                      
-
                 </section>
 
-                  <section id="dashboard__status">
-                            <div class="flex flex-space-between pl-24 pt-8 pb-4 pr-24 modal-top">
-                            <h2 id="connect-wallet-title" class="capitalise header-7">Manage Account</h2>
-                            <button aria-label="Close modal" class="modal-close-btn" id="modal-close-btn">
-                                ✕
-                            </button>
-                        </div>
+                <!-- Shows the status modal -->
+                <section id="dashboard__status" role="dialog" aria-modal="true" aria-labelledby="connect-wallet-title">
 
-                            <div id="status__container" class="">
+                    <!-- Header -->
+                    <div class="flex flex-space-between pl-24 pt-8 pb-4 pr-24 modal-top">
+                        <h2 id="connect-wallet-title" class="capitalise header-8 mt-8 mb-8 light-bold">
+                            Manage account
+                        </h2>
 
-                                <div class="status__head">
-                                
-                                    <div class="status__head_body flex-grid two-column-20_80_grid">
-                                        <div class="img-container">
-                                            <img src="/static/images/card-icons/atlas-bank.png" alt="Elm Financial logo"
-                                                class="status__head-img">
-                                        </div>    
-                                        <div class="status__bank-attributes">
-                                            <p class="mt-48">Elm Financial checking ****1246</p>
-                                        </div>
-                                       
-                                    </div>
-                                    <hr class="dividor">
+                        <button aria-label="Close manage account dialog" class="modal-close-btn" id="modal-close-btn"
+                            type="button">
+                            <span aria-hidden="true">✕</span>
+                        </button>
+                    </div>
+
+                    <div id="status__container" class="pt-8">
+
+                        <!-- Connected account summary -->
+                        <div class="status__head">
+                            <div class="status__head_body flex-grid two-column-20_80_grid">
+
+                                <div class="img-container">
+                                    <img src="/static/images/card-icons/atlas-bank.png" alt="Elm Financial bank logo"
+                                        class="status__head-img">
                                 </div>
 
-                                <div class="status__body pl-24">
-                                  <p>View and manage your connected bank</p>
+                                <div class="status__bank-attributes">
+                                    <p class="mt-48">
+                                        Connected account: Elm Financial checking ending in 1246
+                                    </p>
                                 </div>
-
-                                <div class="status__footer">
-
-                                </div>
-
                             </div>
 
+                            <hr class="dividor">
+                        </div>
 
-                        </section>
+                        <!-- Body -->
+                        <div class="status__body pl-24">
+                            <p id="manage-bank-description" class="mb-8">
+                                View and manage your connected bank account.
+                            </p>
+
+                            <div class="status__body__container">
+
+                                <!-- Bank details -->
+                                <section aria-labelledby="bank-details-title">
+                                    <h3 id="bank-details-title" class="sr-only">
+                                        Bank account details
+                                    </h3>
+
+                                    <dl class="status__bank_details flex-grid two-column-grid">
+
+                                        <div class="bank-name flex flex-space-between">
+                                            <dt>Bank name</dt>
+                                            <dd>Elm Financing</dd>
+                                        </div>
+
+                                        <div class="bank-account flex flex-space-between border-right">
+                                            <dt>Account number</dt>
+                                            <dd>Ending in 7502</dd>
+                                        </div>
+
+                                        <div class="account-type flex flex-space-between">
+                                            <dt>Account type</dt>
+                                            <dd>Current</dd>
+                                        </div>
+
+                                        <div class="account-currency flex flex-space-between border-right">
+                                            <dt>Currency</dt>
+                                            <dd>GBP</dd>
+                                        </div>
+
+                                    </dl>
+                                </section>
+
+                                <!-- Connection info -->
+                                <div class="bank-connection flex flex-space-between mt-8 mb-8">
+
+                                    <span class="bank-entity-type capitalise">
+                                        <i class="fa-solid fa-building-columns" aria-hidden="true"></i>
+                                        Entity type: External bank account
+                                    </span>
+
+                                    <span class="bank-connection-status text-muted" id="bank-connection-status"
+                                        role="status" aria-live="polite">
+                                        Virtual bank connected via
+                                        <i class="fa-solid fa-diagram-project" aria-hidden="true"></i>
+                                        Plaid
+                                    </span>
+                                </div>
+
+                                <!-- Health status -->
+                                <div id="bank-connection">
+
+                                    <div class="connection-check-status">
+
+                                        <div class="connection-status-health">
+                                            <i class="fa-solid fa-check verified" aria-hidden="true"></i>
+                                            <span class="sr-only">Connection healthy</span>
+                                        </div>
+
+                                        <div class="connection-status-description">
+                                            <p class="light-bold">
+                                                Connection is healthy
+                                            </p>
+                                            <p>
+                                                Last synced February 6 2026 at 22:30 hrs
+                                            </p>
+                                        </div>
+                                    </div>
+
+                                    <hr class="dividor">
+
+                                    <!-- Actions -->
+                                    <div class="connection__actions flex-grid two-column-grid">
+
+                                        <button type="button"
+                                            class="connection__button btn-large blue-bg white-text js-refresh-connection">
+                                            <i class="fa-solid fa-arrows-rotate" aria-hidden="true"></i>
+                                            Refresh connection
+                                        </button>
+
+                                        <button type="button"
+                                            class="connection__button btn-large green-bg white-text js-test-connection">
+                                            <i class="fa-solid fa-plug" aria-hidden="true"></i>
+                                            Test connection
+                                        </button>
+
+                                    </div>
+                                </div>
+
+                                <!-- Disconnect information -->
+                                <section class="status__bank-disconnection flex-grid two-column-20_80_grid mt-8"
+                                    aria-labelledby="disconnect-title">
+
+                                    <div class="bank-connection-activities flex-grid">
+                                        <a href="#" class="status__info-link">
+                                            Recent activities
+                                        </a>
+                                    </div>
+
+                                    <div class="disconnection-info mr-48">
+                                        <div class="flex-grid disconnection-info__container">
+
+                                            <div class="disconnection-info-icon center">
+                                                <i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>
+                                            </div>
+
+                                            <div class="disconnection-description">
+                                                <h3 id="disconnect-title" class="header-9">
+                                                    Disconnect wallet or bank account
+                                                </h3>
+
+                                                <p class="mt-4">
+                                                    Disconnecting will stop transaction sync
+                                                    and remove account data from this app.
+                                                </p>
+
+                                                <ul class="mt-8">
+                                                    <li>Synchronisation and display will stop</li>
+                                                    <li>Transaction updates will stop</li>
+                                                    <li>Historical financial data will be removed</li>
+                                                    <li>You must reconnect to access data again</li>
+                                                </ul>
+                                            </div>
+
+                                        </div>
+                                    </div>
+                                </section>
+
+                            </div>
+                        </div>
+
+                        <!-- Footer -->
+                        <div class="status__footer pl-24 flex flex-space-between mr-24 mb-16">
+                            <small class="simulated-environment">
+                                This is a simulated environment
+                            </small>
+
+                            <div class="connection__actions">
+                                <button type="button"
+                                    class="connection__button btn-large white-text disconnect-btn capitalise"
+                                    aria-describedby="disconnect-title">
+                                    <i class="fa-solid fa-xmark" aria-hidden="true"></i>
+                                    Disconnect
+                                </button>
+                            </div>
+                        </div>
+
+                    </div>
+                </section>
+
 
                 <!-- The footer section -->
                 <footer>

--- a/bank/dashboard.html
+++ b/bank/dashboard.html
@@ -366,7 +366,7 @@
                                                     <a href="#" class="btn-large capitalize center bank-dashboard-btn"
                                                         id="connect-wallet-btn">Connect Wallet</a>
                                                     <a href="#" class="btn-large capitalize center bank-dashboard-btn"
-                                                        id="disconnect-wallet">Disconnect</a>
+                                                        id="disconnect-wallet">Status</a>
                                                 </div>
 
                                             </div>
@@ -760,7 +760,7 @@
 
                                 <div id="wallet-auth-completion" class="center mt-8 hide">
                                     <p id="wallet-connect-msg" class="mt-8">Your wallet has successfully been
-                                        connected to your bank account, you can now close the page and proceed to step 3
+                                        verified, you can now close the page and proceed to step 3
                                     </p>
                                     <button id="auth-wallet__cancel-btn" class="btn-semi-medium mt-8 blue-bg white-text"
                                         type="button" data-action="cancel">
@@ -824,8 +824,8 @@
                                     </div>
 
                                     <div class="buttons mt-16 mb-16">
-                                        <button type="submit" class="btn-large blue-bg white-text" id="manually-wallet-link-btn">
-                                            Link Wallet!
+                                        <button type="submit" class="btn-large blue-bg white-text capitalise" id="manually-wallet-link-btn">
+                                            verify Wallet credentials!
                                         </button>
                                     </div>
 
@@ -840,9 +840,47 @@
 
                         </section>
 
+                      
 
                 </section>
 
+                  <section id="dashboard__status">
+                            <div class="flex flex-space-between pl-24 pt-8 pb-4 pr-24 modal-top">
+                            <h2 id="connect-wallet-title" class="capitalise header-7">Manage Account</h2>
+                            <button aria-label="Close modal" class="modal-close-btn" id="modal-close-btn">
+                                ✕
+                            </button>
+                        </div>
+
+                            <div id="status__container" class="">
+
+                                <div class="status__head">
+                                
+                                    <div class="status__head_body flex-grid two-column-20_80_grid">
+                                        <div class="img-container">
+                                            <img src="/static/images/card-icons/atlas-bank.png" alt="Elm Financial logo"
+                                                class="status__head-img">
+                                        </div>    
+                                        <div class="status__bank-attributes">
+                                            <p class="mt-48">Elm Financial checking ****1246</p>
+                                        </div>
+                                       
+                                    </div>
+                                    <hr class="dividor">
+                                </div>
+
+                                <div class="status__body pl-24">
+                                  <p>View and manage your connected bank</p>
+                                </div>
+
+                                <div class="status__footer">
+
+                                </div>
+
+                            </div>
+
+
+                        </section>
 
                 <!-- The footer section -->
                 <footer>

--- a/bank/dashboard.html
+++ b/bank/dashboard.html
@@ -947,12 +947,12 @@
                                         </div>
 
                                         <div class="connection-status-description">
-                                            <p class="light-bold">
+                                            <p class="light-bold" id="connection-status-description__title">
                                                 Connection is healthy
                                             </p>
-                                            <p>
+                                            <small id="sync-time">
                                                 Last synced February 6 2026 at 22:30 hrs
-                                            </p>
+                                            </small>
                                         </div>
                                     </div>
 
@@ -1035,6 +1035,96 @@
                         </div>
 
                     </div>
+                </section>
+
+                <!-- A modal box asking the user to enter disconnect in order to disconnect the modal -->
+                <section id="wallet-disconnection-confirmation" role="dialog" aria-modal="true"
+                    aria-labelledby="wallet-disconnect-modal-title" aria-describedby="wallet-disconnect-warning">
+
+                    <!-- Header -->
+                    <div class="flex flex-space-between pl-24 pt-8 pb-4 pr-24 modal-top">
+
+                        <h2 id="wallet-disconnect-modal-title" class="capitalise header-8 mt-8 mb-8 light-bold">
+                            Disconnect wallet or bank account
+                        </h2>
+
+                        <button aria-label="Close disconnect confirmation dialog" class="modal-close-btn"
+                            id="modal-close-btn" type="button">
+                            <span aria-hidden="true">✕</span>
+                        </button>
+                    </div>
+
+                    <div class="wallet-disconnection-confirmation__container">
+
+                        <!-- Warning block -->
+                        <div class="flex-grid disconnection-info__container mt-16 mb-16">
+
+                            <div class="disconnection-info-icon center">
+                                <i class="fa-solid fa-triangle-exclamation" aria-hidden="true"></i>
+                            </div>
+
+                            <div class="disconnection-description">
+
+                                <h3 id="wallet-disconnect-title" class="header-9 disconnect-heading light-bold">
+                                    Are you sure you want to disconnect this external bank account?
+                                </h3>
+
+                            </div>
+                        </div>
+
+                        <!-- Consequences -->
+                        <ul id="wallet-disconnect-warning" class="mt-4 ml-16 mr-16 mb-16 pt-16 pb-16 flex-grid">
+                            <li>Synchronisation and display will stop</li>
+                            <li>Transaction updates will stop</li>
+                            <li>Historical financial data will be removed</li>
+                            <li>You must reconnect to access data again</li>
+                        </ul>
+
+                        <!-- Confirmation instruction -->
+                        <p id="disconnect-confirm-instruction" class="ml-16">
+                            Please type <strong>DISCONNECT</strong> below to confirm.
+                        </p>
+
+                        <!-- Input -->
+                        <div id="confirmation-disconnection-input-field"
+                            class="flex-grid two-column-20_80_grid ml-16 mr-16 mb-16 mt-8">
+
+                            <div class="lock center p-8">
+                                <i class="fa-solid fa-lock" aria-hidden="true"></i>
+                                <span class="sr-only">Secure confirmation input</span>
+                            </div>
+
+                            <div class="form-row">
+                                <label for="wallet-disconnect" class="sr-only">
+                                    Type DISCONNECT to confirm bank disconnection
+                                </label>
+
+                                <form action="" method="post">
+                                      <input type="text" name="wallet-disconnect" id="wallet-disconnect" maxlength="10"
+                                       minlength="10" aria-describedby="disconnect-confirm-instruction" autocomplete="off" required>
+
+                                       
+                                </form>
+
+                              
+                            </div>
+
+                        </div>
+                    </div>
+
+                    <!-- Footer -->
+                    <div id="wallet-disconnection-confirmation__footer" class="flex flex-end mr-16 mb-24">
+
+                        <button type="button" class="cancel-disconnect-btn mr-8">
+                            Cancel
+                        </button>
+
+                        <button type="submit" class="confirm-disconnect-btn">
+                            Disconnect account
+                        </button>
+
+                    </div>
+
                 </section>
 
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2240,12 +2240,12 @@ time {
     background: var(--blue-600);
 }
 
-#disconnect-wallet {
+#disconnect-wallet-status {
     background: var(--red);
 }
 
 #connect-wallet-btn,
-#disconnect-wallet {
+#disconnect-wallet-status {
     color: white;
 }
 
@@ -2277,7 +2277,6 @@ time {
     scale: var(0.9);
 }
 
-#dashboard__status,
 #link-wallet-verifcation,
 #connect-with-wallet-id,
 #connect-wallet-modal {
@@ -2302,10 +2301,6 @@ time {
 
 }
 
-#connect-with-wallet-id.show {
-    display: grid;
-  
-}
 
 
 #connect-wallet-modal h2 {
@@ -2413,6 +2408,9 @@ time {
 
 }
 
+
+#dashboard__status.show,
+#wallet-disconnection-confirmation.show,
 #connect-with-wallet-id.show,
 #connect-wallet-modal.show,
 #connect-wallet-modal__step-one.show,
@@ -2632,6 +2630,12 @@ time {
 /* This is the part of the modal in the dashboard that will open up the modal when the user hits
  status button
 */
+
+#dashboard-status-modal-close-btn {
+    position: relative;
+    z-index: 10000;
+}
+
 .img-container {
     position: relative;
     height: 133px;
@@ -2663,6 +2667,7 @@ time {
   text-transform: capitalize;
   
 }
+
 
 .wallet-disconnection-confirmation__container p,
 .dsiconnection-description h2,
@@ -2708,8 +2713,11 @@ time {
     box-shadow: var(--box-shadow-primary);
     cursor: pointer;
     border: 2px solid black;
+    background: white;
     border-radius: 8px;
+    display: none;
 }
+
 
 
 #bank-connection {
@@ -2808,7 +2816,7 @@ time {
     position: fixed;
     left: 32%;
     top: 20%;
-    z-index: 100000;
+    z-index: 1000;
      width: 40%;
     margin: auto;
     background: #ffff;
@@ -2816,7 +2824,11 @@ time {
     border-radius: 4px;
     cursor: pointer;
     box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
+    border: 1px solid black;
+    display: none;
+   
 }
+
 
 #wallet-disconnect-title span {
     font-size: 0.94rem;
@@ -2853,7 +2865,7 @@ time {
     font-weight: bold;
 }
 
-.confirm-disconnect-btn {
+#confirm-disconnect-btn {
     background: var(--red);
     color: white;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -147,6 +147,9 @@ body {
     margin-right: var(--space-16);
 }
 
+.mr-24 {
+    margin-right: var(--space-24); 
+}
 /* Bottom */
 .mb-4 {
     margin-bottom: var(--space-4);
@@ -1857,6 +1860,14 @@ label {
 
 }
 
+.verified {
+    border: 1px solid;
+    border-radius: 50%;
+    background: green;
+    color: white;
+    padding: 2px;
+}
+
 
 .bank-completion__row dd.active {
     font-weight: bold;
@@ -2616,6 +2627,9 @@ time {
 
 
 /* status button modal section*/
+/* This is the part of the modal in the dashboard that will open up the modal when the user hits
+ status button
+*/
 .img-container {
     position: relative;
     height: 133px;
@@ -2632,6 +2646,154 @@ time {
 
 .status__head_body {
     transform: translateY(-45px);
-    grid-template-rows: 16px;
+    grid-template-rows: 20px;
     padding-left: 24px;
+}
+
+
+.status__bank_details div {
+    border: 2px solid lavender;
+    padding: var(--space-8);
+}
+
+.status__bank_details div dt {
+  font-weight: 500;
+  text-transform: capitalize;
+  
+}
+
+.dsiconnection-description h2,
+.status__info-link,
+.status__head p,
+.status__body p,
+.bank-connection span,
+.status__bank_details div dt,
+.status__bank_details div dd {
+  font-size: 0.9rem;
+}
+
+.bank-connection {
+    background: ghostwhite;
+    padding: var(--space-8);
+}
+
+.status__body__container {
+ 
+  border: 2px solid lavender;
+  margin-right: var(--space-48);
+  padding: var(--space-16);
+  margin-bottom: var(--space-12);
+  margin-right: var(--space-24);
+  
+}
+
+#bank-connection-status {
+    border: 1px solid black;
+    margin-right: var(--space-4);
+    padding: var(--space-4);
+    font-size: 0.8rem;
+}
+
+
+#dashboard__status {
+    position: fixed;
+    top: 0;
+    left: 28%;
+    width: 47%;
+    margin: auto;
+    z-index: 1000;
+    box-shadow: var(--box-shadow-primary);
+    cursor: pointer;
+    border: 2px solid black;
+    border-radius: 8px;
+}
+
+
+#bank-connection {
+    box-shadow: var(--box-shadow-primary);
+    margin-top: var(--space-4);
+    margin-bottom: var(--space-4);
+    padding: var(--space-12);
+    border-radius: 8px;
+}
+
+.connection__actions {
+    column-gap: var(--space-4);
+}
+
+.connection__button {
+    text-align: center;
+    font-size: 0.9rem;
+    padding: var(--space-4);
+    margin-top: var(--space-8);
+    border-radius: 8px; 
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    font-weight: 600;
+    transition: transform 0.1s ease, box-shadow 0.1s ease;
+    gap: 0.5rem; /*Space between icon and text*/
+    padding-top: var(--space-4);
+    padding-bottom: var(--space-4);
+}
+
+
+.connection__button:hover {
+    transform: translateY(-1px); 
+    box-shadow: 0 4px 6px rgba(0,0,0,0.15); 
+}
+
+.disconnection-description ul li {
+    list-style: disc;
+    margin-left: var(--space-8);
+    font-size: 0.85rem;
+    color: #333;
+    line-height: 1.5;
+}
+
+
+.disconnection-info {
+    background: #FFF8E1;
+    border: 1px solid #FFE082;
+    padding: var(--space-8);
+    border-radius: 8px;
+     color: #333333;
+}
+
+
+.disconnection-info-icon i {
+    font-size: 1.5rem;
+    color: #E6A700;
+}
+
+
+.status__bank-disconnection {
+    column-gap: var(--space-4);
+}
+
+.disconnection-info__container {
+    display: grid;
+    grid-template-columns: 10% 90%;
+    grid-template-rows: auto;
+    column-gap: 1px;
+}
+
+
+.disconnect-btn {
+    background: var(--red);
+    padding-left: var(--space-8);
+    padding-right: var(--space-8);
+ 
+}
+
+.disconnect-btn:hover {
+   
+    background: black;
+    color: white;
+   
+}
+
+.connection-check-status {
+    display: grid;
+    grid-template-columns: 5% 95%;
+    grid-template-rows: auto;
+    column-gap: var(--space-4);
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -30,6 +30,8 @@
     --box-shadow-tietary: rgba(0, 0, 0, 0.12) 0px 1px 3px, rgba(0, 0, 0, 0.24) 0px 1px 2px;
     --gradient-blue: linear-gradient(135deg, #0F4C81 0%, #1CB5E0 100%);
 
+    --warning-color: #FFF8E1;
+
 }
 
 
@@ -2662,6 +2664,7 @@ time {
   
 }
 
+.wallet-disconnection-confirmation__container p,
 .dsiconnection-description h2,
 .status__info-link,
 .status__head p,
@@ -2741,6 +2744,7 @@ time {
     box-shadow: 0 4px 6px rgba(0,0,0,0.15); 
 }
 
+.wallet-disconnection-confirmation__container ul li,
 .disconnection-description ul li {
     list-style: disc;
     margin-left: var(--space-8);
@@ -2751,11 +2755,11 @@ time {
 
 
 .disconnection-info {
-    background: #FFF8E1;
+    background: var(--warning-color);
     border: 1px solid #FFE082;
     padding: var(--space-8);
     border-radius: 8px;
-     color: #333333;
+    color: #333333;
 }
 
 
@@ -2796,4 +2800,60 @@ time {
     grid-template-columns: 5% 95%;
     grid-template-rows: auto;
     column-gap: var(--space-4);
+}
+
+
+/* Disconnection wallet confirmation modal attribrutes */
+#wallet-disconnection-confirmation {
+    position: fixed;
+    left: 32%;
+    top: 20%;
+    z-index: 100000;
+     width: 40%;
+    margin: auto;
+    background: #ffff;
+    border: 1px solid lavender;
+    border-radius: 4px;
+    cursor: pointer;
+    box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
+}
+
+#wallet-disconnect-title span {
+    font-size: 0.94rem;
+}
+#wallet-disconnect-title span:last-child {
+    font-weight: 400;
+}
+
+.wallet-disconnection-confirmation__container ul {
+    background: var(--warning-color);
+    border: 4px solid var(--warning-color);
+    
+}
+
+.wallet-disconnection-confirmation__container ul li {
+    margin-left: var(--space-16);
+
+}
+
+#confirmation-disconnection-input-field .lock {
+    background: lavender;
+}
+
+#confirmation-disconnection-input-field .form-row input {
+    text-transform: uppercase;
+    border: 2px solid lavender;
+    outline: none;
+    box-shadow: none;
+}
+
+#wallet-disconnection-confirmation__footer button {
+    border-radius: 0px;
+    padding: var(--space-12);
+    font-weight: bold;
+}
+
+.confirm-disconnect-btn {
+    background: var(--red);
+    color: white;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1086,7 +1086,7 @@ footer {
     padding-right: var(--space-16);
     padding-left: var(--space-16);
     color: white;
-    font-size: 0.85rem;
+    font-size: 0.75rem;
     text-transform: capitalize;
 }
 
@@ -2264,7 +2264,7 @@ time {
     scale: var(0.9);
 }
 
-
+#dashboard__status,
 #link-wallet-verifcation,
 #connect-with-wallet-id,
 #connect-wallet-modal {
@@ -2612,4 +2612,26 @@ time {
 
 #manually-wallet-link-btn {
     font-size: 1rem;
+}
+
+
+/* status button modal section*/
+.img-container {
+    position: relative;
+    height: 133px;
+    width: 150px;
+    transform: translateX(-45px);
+   
+}
+
+.img-container img {
+    position: absolute;
+    height: 100%;
+    width: 100%;
+}
+
+.status__head_body {
+    transform: translateY(-45px);
+    grid-template-rows: 16px;
+    padding-left: 24px;
 }

--- a/static/js/dashboard/bank-dashboard.js
+++ b/static/js/dashboard/bank-dashboard.js
@@ -22,7 +22,7 @@ const walletOptionAuthInputFields = document.querySelectorAll("#connect-wallet-a
 let walletModalStep2Button;
 
 const excludeFields = new Set(["username", "email", "password"]);
-const excludeTypes = new Set(["checkbox", "radio"]);
+const excludeTypes = new Set(["checkbox", "radio", "text"]);
 
 // console.log(walletOptionAuthInputFields)
 


### PR DESCRIPTION
## Goal

This commit introduces a modal dialog that opens a dialog box after the user clicks "disconnect" button. This dialogue requires the user to explicitly type **“DISCONNECT”** in order to disconnect a wallet from external bank account. This ensures that disconnection is deliberate and prevents accidental removal of wallet access and associated financial data.

Also add a confirmation alert when the user clicks `refresh connection` and `Test connection`. This only alerts the user but does nothing at the backend, that will be handle later by her
## Changes

* Added a new confirmation modal (`wallet-disconnection-confirmation`) with proper ARIA roles for accessibility.
* Included warning messages about what will happen if a wallet is disconnected:

  * Synchronisation and display will stop
  * Transaction updates will stop
  * Historical financial data will be removed
  * Reconnection is required to access data again
* Added an input field where the user must type **DISCONNECT** to enable the confirm button.
* Added JS logic to:
  * Handle input validation and enable confirmation only if the input matches exactly.
  * Show confirmation alerts before proceeding.
  * Close panels and clear input fields on cancel or successful disconnection.
* Updated event delegation to handle button clicks and modal actions without triggering unintended panels.
Added the CSS rules
Add a confirmation alert when the user clicks `refresh connection` and `Test connection`. This only opens up a confirmation dialogue box but takes no action since the backend isn't created yet

## Usage Notes

Users can now:

1. Open the wallet disconnection modal from the dashboard by clicking "status"
2. Read the warnings and consequences.
3. Type **DISCONNECT** into the input field to confirm.
4. Click **Disconnect account** to execute disconnection.
5. Click **Cancel** to close the modal without performing any action.

If the confirmation input is incorrect or incomplete, the disconnect action is blocked.

## Workflow

User clicks the **Status** button on the wallet
*  User clicks **Disconnect** on the wallet status panel.
*  The disconnection confirmation modal opens.
*  User reads the warnings.
* User types **DISCONNECT** in the input field.
* User clicks **Disconnect account**.
* A confirmation alert appears.
* If confirmed, the modal closes and the wallet is disconnected.
* If canceled, the modal closes and no action is taken.
Users can cancel or close the confirmation dialogue by cancelling button or x-button
User can click "refresh connection" or "Test connection"

## TODO (future updates)

* Integrate backend logic to handle actual wallet disconnection requests.
* Add loading and error states for network requests.
* Add mobile layout and responsiveness to all pages.

## Notes

* This commit focuses on frontend behaviour only; no backend verification is performed yet.
* Accessibility and ARIA roles are included to improve screen reader support.
* Styling follows existing dashboard modal patterns, with warning icons and clear instructions.

