### PR TITLE
Fix scroll bar problem

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -68,12 +68,15 @@ body {
     background-repeat: no-repeat;
     min-height: 100vh;
     background: #f6f9fc;
+ 
 
 
 
 }
 
-
+html {
+    overflow: hidden;
+}
 /* All sides */
 .m-0 {
     margin: var(--space-0);
@@ -3256,6 +3259,7 @@ clicks the button
 #transaction-report table {
     width: 100%;
     
+    
 }
 
 
@@ -3280,8 +3284,11 @@ clicks the button
     column-gap: var(--space-16);
 }
 
+
 #transaction-report {
     font-size: 0.875rem; /* 14px */
+    overflow-y: auto;
+   
 }
 
 #transaction-report th,
@@ -3312,3 +3319,7 @@ clicks the button
     color: #444;
     margin-bottom: 0.5rem; 
 }
+
+
+
+


### PR DESCRIPTION
The page was showing two scrollbars an inner scroll and an outer scroll. The outer scroll controlled the main page, while the inner scroll controlled the transaction section. However, the inner scroll would disappear when hovering over a card and reappear when moving the pointer away. On top of that, when the outer scroll was used, some elements in the main body remained hidden until the inner scroll was activated, causing inconsistent rendering of content.

Added `overflow: hidden` to the `html` element. This prevents unwanted inner scrollbars and ensures that hidden elements do not cause rendering issues. This also ensures that there is only one scroll bar the main one and that all that all main content displays correctly when it is scrolled.

Added and then refreshed the page:

html {
    overflow: hidden;
}