### PR TITLE
Dashboard  bank card overview

### DIFF
--- a/bank/dashboard.html
+++ b/bank/dashboard.html
@@ -511,6 +511,141 @@
                             </section>
 
 
+                            <!-- my cards overview -->
+                            <section id="bank-my-cards" class="mb-24" aria-labelledby="my-cards-heading">
+                                <div class="bank-my-cards__container ml-24 p-16">
+                                  
+                                    <h2 id="my-cards-heading" class="header-7 capitalise mb-8">My credit cards overview
+                                    </h2>
+
+                                    <!-- Informational notes -->
+                                    <p class="bank-my-card-info--note">
+                                        You can add up to 5 cards, but only 3 will appear on your dashboard.
+                                    </p>
+                                    <p class="bank-my-card-info--note">
+                                        Pick which cards to display in your dashboard settings.
+                                    </p>
+
+                                    <hr class="dividor">
+
+                                    <!-- Cards container -->
+                                    <div id="bank-my-cards-overview"
+                                        class="cards flex-grid three-column-grid mt-8 mb-8">
+
+                                        <!-- Card 1 -->
+                                        <div class="bank-card credit-visa-card" role="region"
+                                            aria-label="Atlas Bank Visa Credit Card, balance £100.00">
+                                            <div class="card-head">
+                                                <div class="card-head-info">
+                                                    <h3>Atlas Bank</h3>
+                                                    <p class="bank-card-amount">£100.00</p>
+                                                </div>
+
+                                                <div class="card-type-logo flex flex-end">
+                                                    <img src="/static/images/icons/visa.svg" alt="Visa logo">
+                                                </div>
+                                            </div>
+
+                                            <div class="card-body">
+                                                <div class="chip">
+                                                    <img src="/static/images/icons/sim-card-chip.svg" alt="Card chip">
+                                                </div>
+
+                                                <div class="credit-transaction-type flex flex-end">
+                                                    <span>Credit card</span>
+                                                </div>
+
+                                                <div class="card-number flex flex-end">
+                                                    <span class="card-number">4434-9628-1011-1224</span>
+                                                </div>
+                                            </div>
+
+                                            <div class="card-footer flex flex-space-between">
+                                                <div class="card-name">Johnathan Doe</div>
+                                                <div class="card-expiry-date">
+                                                    <p>Expiry date: January 2029</p>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <!-- Card 2 -->
+                                        <div class="bank-card credit-master-card" role="region"
+                                            aria-label="Atlas Bank Mastercard Credit Card, balance £7.26">
+                                            <div class="card-head">
+                                                <div class="card-head-info">
+                                                    <h3>Atlas Bank</h3>
+                                                    <p class="bank-card-amount">£7.26</p>
+                                                </div>
+
+                                                <div class="card-type-logo flex flex-end">
+                                                    <img src="/static/images/icons/mastercard.svg"
+                                                        alt="Mastercard logo">
+                                                </div>
+                                            </div>
+
+                                            <div class="card-body">
+                                                <div class="chip">
+                                                    <img src="/static/images/icons/sim-card-chip.svg" alt="Card chip">
+                                                </div>
+
+                                                <div class="credit-transaction-type flex flex-end">
+                                                    <span>Credit card</span>
+                                                </div>
+
+                                                <div class="card-number flex flex-end">
+                                                    <span class="card-number">2234-5678-1011-1224</span>
+                                                </div>
+                                            </div>
+
+                                            <div class="card-footer flex flex-space-between">
+                                                <div class="card-name">Jane Doe</div>
+                                                <div class="card-expiry-date">
+                                                    <p>Expiry date: January 2028</p>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                        <!-- Card 3 -->
+                                        <div class="bank-card credit-discover-card" role="region"
+                                            aria-label="Atlas Bank Discover Debit Card, balance £2.00">
+                                            <div class="card-head">
+                                                <div class="card-head-info">
+                                                    <h3>Atlas Bank</h3>
+                                                    <p class="bank-card-amount">£2.00</p>
+                                                </div>
+
+                                                <div class="card-type-logo flex flex-end">
+                                                    <img src="/static/images/icons/discover.svg" alt="Discover logo">
+                                                </div>
+                                            </div>
+
+                                            <div class="card-body">
+                                                <div class="chip">
+                                                    <img src="/static/images/icons/sim-card-chip.svg" alt="Card chip">
+                                                </div>
+
+                                                <div class="credit-transaction-type flex flex-end">
+                                                    <span>Debit card</span>
+                                                </div>
+
+                                                <div class="card-number flex flex-end">
+                                                    <span class="card-number">1734-5978-1011-1224</span>
+                                                </div>
+                                            </div>
+
+                                            <div class="card-footer flex flex-space-between">
+                                                <div class="card-name">Johnathan Doe</div>
+                                                <div class="card-expiry-date">
+                                                    <p>Expiry date: January 2027</p>
+                                                </div>
+                                            </div>
+                                        </div>
+
+                                    </div>
+                                </div>
+                            </section>
+
+
                         </div>
 
 
@@ -980,6 +1115,8 @@
                             </div>
 
                         </section>
+
+
 
                 </section>
 

--- a/static/css/css.css
+++ b/static/css/css.css
@@ -1764,3 +1764,6 @@ input::placeholder {
     cursor: no-drop;
     opacity: 0.4;
   }
+
+
+

--- a/static/css/css.css
+++ b/static/css/css.css
@@ -1764,6 +1764,3 @@ input::placeholder {
     cursor: no-drop;
     opacity: 0.4;
   }
-
-
-

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -643,6 +643,7 @@ header {
     text-align: center;
 }
 
+.bank-card:hover,
 .call-to-action__button:hover {
     transform: translateY(-4px);
 }
@@ -2922,7 +2923,7 @@ time {
 
 .dashboard__container__main__wrapper {
     display: grid;
-    grid-template-columns: 60% 40%;
+    grid-template-columns: 75% 25%;
     grid-template-rows: auto;
     column-gap: var(--space-8);
 }
@@ -3321,5 +3322,74 @@ clicks the button
 }
 
 
+/* The card section including some resuable class names for the individual card */
+#bank-my-cards {
+    background: #ffff;
+}
 
+#bank-my-cards-overview {
+    column-gap: var(--space-8);
+}
 
+.bank-card {
+
+   font-size: 0.75rem;
+   padding: var(--space-8);
+   cursor: pointer;
+   border-radius: 4px;
+   border-radius: 10px;
+   box-shadow:
+  0 25px 50px rgba(0,0,0,0.4),
+  inset 0 0 30px rgba(56,189,248,0.15);
+   color: #F5F5F5;
+
+}
+
+.bank-card .card-head .card-head-info h3 {
+    font-size: 0.8rem;
+}
+
+.bank-card .card-footer {
+ font-size: 0.7rem;
+ font-weight: 600;
+}
+.bank-card .card-body .chip img {
+    height: 25px;
+}
+
+.card-chip-img {
+    height: 40px;
+}
+
+.card-type-logo img {
+    height: 30px;
+}
+
+.card-number {
+    color: #EDEDED;
+    letter-spacing: var(--space-4);
+    font-weight: 600;
+    margin-bottom: var(--space-4);
+}
+
+.credit-transaction-type {
+    text-transform: capitalize;
+}
+
+.credit-visa-card {
+  background: linear-gradient(135deg, #0A2540, #1D4ED8, #38BDF8);
+
+}
+
+.credit-master-card {
+ background: linear-gradient(135deg, #2B0A0A, #7F1D1D, #EF4444);
+
+}
+
+.credit-discover-card {
+    background: linear-gradient(135deg, #3B1D0A, #C2410C, #F59E0B);
+}
+
+.bank-my-card-info--note {
+    font-size: 0.9rem;
+}


### PR DESCRIPTION
## feat(dashboard): Add credit Cards to overview panel

## Goal

The goal of this commit is to introduce the **Bank Cards overview panel** in the dashboard with full along **screen reader and accessibility support**. This allows users to view their credit and debit cards clearly within the dashboard but only 3 at a time.

## Changes

- Added a **Bank Cards overview** layout containing:
  - Informational notes about card limits and dashboard display
  - Cards container with a **three-column grid**
- Added meaningful **alt text** for all logos and card chip images
- Ensured **transaction type and expiry dates** use full readable text (e.g., `Credit card`, `January 2029`)
- Structured card layout with clear **header, body, and footer** sections for logical reading order
- Added the necessary CSS to bring it to life

## Workflow

1. **User navigates to the Bank Cards panel** in the dashboard at the bottom of the page.
2. Each card is presented as a distinct card with:
   - bank name, card type, and balance.
  - Includes cardholder name and expiry date.


Note:

- Like all the other pages this is not responsive and will handled at another date
- The numbers are not masked that will be handled when the backend is built
- All the cards are dummy cards to see how it will look, that will be replaced with a dynamic cards