### PR TITLE
Dashboard  bank card detailed view

### DIFF
--- a/bank/dashboard.html
+++ b/bank/dashboard.html
@@ -514,7 +514,7 @@
                             <!-- my cards overview -->
                             <section id="bank-my-cards" class="mb-24" aria-labelledby="my-cards-heading">
                                 <div class="bank-my-cards__container ml-24 p-16">
-                                  
+
                                     <h2 id="my-cards-heading" class="header-7 capitalise mb-8">My credit cards overview
                                     </h2>
 
@@ -534,7 +534,9 @@
 
                                         <!-- Card 1 -->
                                         <div class="bank-card credit-visa-card" role="region"
-                                            aria-label="Atlas Bank Visa Credit Card, balance £100.00">
+                                            aria-label="Atlas Bank Visa Credit Card, balance £100.00"
+                                            data-card-id="card_92f3a1" data-issued="2026-02-11" data-is-active="true"
+                                            data-card-brand="visa" data-creation-date="2026-02-11" data-cvc="***">
                                             <div class="card-head">
                                                 <div class="card-head-info">
                                                     <h3>Atlas Bank</h3>
@@ -552,25 +554,27 @@
                                                 </div>
 
                                                 <div class="credit-transaction-type flex flex-end">
-                                                    <span>Credit card</span>
+                                                    <span class="card-type">Credit</span>
                                                 </div>
 
                                                 <div class="card-number flex flex-end">
-                                                    <span class="card-number">4434-9628-1011-1224</span>
+                                                    <span class="card-number">************1224</span>
                                                 </div>
                                             </div>
 
                                             <div class="card-footer flex flex-space-between">
                                                 <div class="card-name">Johnathan Doe</div>
                                                 <div class="card-expiry-date">
-                                                    <p>Expiry date: January 2029</p>
+                                                    Expiry date: January 2029
                                                 </div>
                                             </div>
                                         </div>
 
                                         <!-- Card 2 -->
-                                        <div class="bank-card credit-master-card" role="region"
-                                            aria-label="Atlas Bank Mastercard Credit Card, balance £7.26">
+                                        <div class="bank-card credit-mastercard-card" role="region"
+                                            aria-label="Atlas Bank Mastercard Credit Card, balance £7.26"
+                                            data-card-id="card_92f3a2" data-issued="2026-02-12" data-is-active="true"
+                                            data-card-brand="mastercard" data-creation-date="2026-02-11" data-cvc="***">
                                             <div class="card-head">
                                                 <div class="card-head-info">
                                                     <h3>Atlas Bank</h3>
@@ -589,11 +593,11 @@
                                                 </div>
 
                                                 <div class="credit-transaction-type flex flex-end">
-                                                    <span>Credit card</span>
+                                                    <span class="card-type">Credit</span>
                                                 </div>
 
                                                 <div class="card-number flex flex-end">
-                                                    <span class="card-number">2234-5678-1011-1224</span>
+                                                    <span class="card-number">************1224</span>
                                                 </div>
                                             </div>
 
@@ -607,7 +611,9 @@
 
                                         <!-- Card 3 -->
                                         <div class="bank-card credit-discover-card" role="region"
-                                            aria-label="Atlas Bank Discover Debit Card, balance £2.00">
+                                            aria-label="Atlas Bank Discover Debit Card, balance £2.00"
+                                            data-card-id="card_92f3a3" data-issued="2026-02-12" data-is-active="false"
+                                            data-card-brand="discover" data-creation-date="2026-02-11" data-cvc="***">
                                             <div class="card-head">
                                                 <div class="card-head-info">
                                                     <h3>Atlas Bank</h3>
@@ -625,11 +631,12 @@
                                                 </div>
 
                                                 <div class="credit-transaction-type flex flex-end">
-                                                    <span>Debit card</span>
+                                                    <span class="card-type">Credit</span>
                                                 </div>
 
                                                 <div class="card-number flex flex-end">
-                                                    <span class="card-number">1734-5978-1011-1224</span>
+                                                    <span class="card-number">***********1224</span>
+
                                                 </div>
                                             </div>
 
@@ -1789,6 +1796,27 @@
                         </div>
 
                     </div>
+                </section>
+
+
+                <!-- card modal -->
+                <section id="view-card-panel">
+
+                    <div class="view-card-panel__container p-48 center">
+
+                        <h2 class="capitalise light-bold">Card details</h2>
+
+                        <div id="full-card-details">
+                            Click on any card
+                        </div>
+
+                        <div id="full-card-details-info" class="text-align-left">
+
+                        </div>
+
+                    </div>
+
+
                 </section>
 
 

--- a/bank/dashboard.html
+++ b/bank/dashboard.html
@@ -526,6 +526,15 @@
                                         Pick which cards to display in your dashboard settings.
                                     </p>
 
+                                    <h3 class="mt-16 mb-4">Note</h3>
+                                    <p>
+                                        Select a card to view extra information. If a card is selected and the
+                                        <span class="light-bold">view card details</span> button is not clicked within 5
+                                        seconds,
+                                        the card will automatically be deselected.
+                                    </p>
+
+
                                     <hr class="dividor">
 
                                     <!-- Cards container -->
@@ -1800,24 +1809,37 @@
 
 
                 <!-- card modal -->
-                <section id="view-card-panel">
+                <article id="view-card-panel">
 
                     <div class="view-card-panel__container p-48 center">
 
-                        <h2 class="capitalise light-bold">Card details</h2>
+                        <h3 class="capitalise light-bold">Card details</h3>
 
                         <div id="full-card-details">
                             Click on any card
                         </div>
 
                         <div id="full-card-details-info" class="text-align-left">
+                            <!-- render dynamically with js -->
+                        </div>
 
+                        <div class="view-card-panel-buttons flex four-column-grid mt-8 mb-8 ">
+                            <button class="btn-large view-card-panel-button" id="card-transfer-btn">Transfer</button>
+                            <button class="btn-large view-card-panel-button" id="card-add-btn">Add</button>
+                            <button class="btn-large view-card-panel-button" id="card-freeze-btn">freeze</button>
+                            <button class="btn-large view-card-panel-button" id="card-close-btn">close</button>
                         </div>
 
                     </div>
 
 
-                </section>
+                </article>
+
+                <button id="view-more-bank-card" type="button">
+                    View card details
+
+                </button>
+
 
 
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -381,6 +381,13 @@ img:hover {
     color: beige;
 }
 
+.active-text {
+    color: var(--green-600);
+}
+
+.deactivate-text {
+    color: var(--red);
+}
 
 /* utilities */
 
@@ -2320,6 +2327,7 @@ time {
     scale: var(0.9);
 }
 
+#view-card-panel,
 #bank-account-view-transactions,
 #bank-account-add-funds,
 #link-wallet-verifcation,
@@ -3213,6 +3221,8 @@ clicks the button
 }
 
 
+/* override it */
+#view-card-panel,
 #bank-account-add-funds {
     top: 0;
     width: 35%;
@@ -3381,7 +3391,7 @@ clicks the button
 
 }
 
-.credit-master-card {
+.credit-mastercard-card {
  background: linear-gradient(135deg, #2B0A0A, #7F1D1D, #EF4444);
 
 }
@@ -3392,4 +3402,27 @@ clicks the button
 
 .bank-my-card-info--note {
     font-size: 0.9rem;
+}
+
+
+
+#view-card-panel {
+
+    /* This will be set to none, using it as grid to see what's being created */
+    display: grid;
+    top: 0;
+    left: 0;
+   
+}
+
+
+#full-card-details {
+    text-align: initial;
+    margin-bottom: var(--space-8);
+   
+}
+
+#full-card-details .bank-card {
+  box-shadow: initial;
+  padding: var(--space-12);
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -650,6 +650,7 @@ header {
     text-align: center;
 }
 
+.view-card-panel-button:hover,
 .bank-card:hover,
 .call-to-action__button:hover {
     transform: translateY(-4px);
@@ -1610,10 +1611,11 @@ label {
 }
 
 .choose-bank__card.is-selected {
+     /* Emerald 500 */
     border: 2px solid #10B981;
-    /* Emerald 500 */
+   
     background-color: #ECFDF5;
-    /* Soft green tint */
+  
     transform: translateY(-2px);
     box-shadow: 0 6px 16px rgba(16, 185, 129, 0.15);
 
@@ -2464,7 +2466,8 @@ time {
 
 }
 
-
+#view-card-panel.show,
+.view-card-panel-buttons.show,
 #dashboard__status.show,
 #wallet-disconnection-confirmation.show,
 #connect-with-wallet-id.show,
@@ -3352,7 +3355,7 @@ clicks the button
   0 25px 50px rgba(0,0,0,0.4),
   inset 0 0 30px rgba(56,189,248,0.15);
    color: #F5F5F5;
-
+   
 }
 
 .bank-card .card-head .card-head-info h3 {
@@ -3405,13 +3408,11 @@ clicks the button
 }
 
 
-
+/* override certain elements in the card panel but still maintain must of the elements */
 #view-card-panel {
-
-    /* This will be set to none, using it as grid to see what's being created */
-    display: grid;
     top: 0;
     left: 0;
+    width: 25%;
    
 }
 
@@ -3425,4 +3426,88 @@ clicks the button
 #full-card-details .bank-card {
   box-shadow: initial;
   padding: var(--space-12);
+}
+
+#full-card-details-info p + p {
+    margin-top: var(--space-4)
+}
+
+
+.bank-card.is-selected {
+  transform: scale(0.8);
+  background: var(--red);
+  transition: transform 0.4s linear;
+
+}
+
+.view-card-panel-buttons {
+    column-gap: 2px;
+    display: none;
+}
+
+.view-card-panel-button {
+    border: 1px solid lavender;
+    color: white;
+    font-weight: 500;
+    border-radius: 8px;
+    text-transform: capitalize;
+}
+
+#card-transfer-btn {
+    background: var(--blue-600);
+}
+
+#card-add-btn {
+    background: var(--green-600);
+}
+
+#card-freeze-btn {
+    background: var(--red);
+}
+
+#card-close-btn {
+   border: 1px solid black;
+   color: black;
+}
+
+
+
+#view-more-bank-card {
+    font-size: 0.85rem;
+    position: fixed;
+    top: 0;
+    right: 20px;
+    border: 1px solid;
+    background: black;
+    color: white;
+    width: 18%;
+    text-align: center;
+    padding: 4px 0;
+    cursor: pointer;
+    text-transform: capitalize;
+
+    /* hidden state */
+    transform: translateY(-120%);
+    transition: transform 0.3s ease-in-out;
+}
+
+
+#view-more-bank-card.show {
+     transform: translateY(0);
+}
+
+
+
+
+
+.field-label { opacity: 0.7; }
+.field-value { 
+    font-weight: 600; 
+    
+
+}
+
+.field-label,
+.field-value {
+    font-size: 0.96rem;
 }

--- a/static/js/card/cardBuilder.js
+++ b/static/js/card/cardBuilder.js
@@ -295,8 +295,7 @@ export function createCardDetails(cardDetails) {
     { fieldName: "Card Brand", fieldValue: cardDetails.cardBrand },
     { fieldName: "Card Type", fieldValue: cardDetails.cardType },
     { fieldName: "CVC", fieldValue: cardDetails.cardCVC },
-    { fieldName: "Expiry Month", fieldValue: cardDetails.expiryMonth },
-    { fieldName: "Expiry Year", fieldValue: cardDetails.expiryYear },
+    { fieldName: "Expiry date", fieldValue: cardDetails.expiryYear },
     { fieldName: "Creation Date", fieldValue: cardDetails.cardCreationDate },
     { fieldName: "Issue Date", fieldValue: cardDetails.issueDate }
 ];
@@ -313,15 +312,30 @@ export function createCardDetails(cardDetails) {
 }
 
 
+/**
+ * Creates and appends a field row to a container.
+ *
+ * Output example:
+ *   Card Number: **** 1234
+ *
+ * @param {string} fieldName - Label for the field.
+ * @param {string} fieldDescription - Value/content of the field.
+ * @param {HTMLElement} divToAddTo - Container to append the field to.
+ */
 function createFieldElement(fieldName, fieldDescription, divToAddTo) {
     const pTag = document.createElement("p");
 
     const label = document.createElement("span");
-    label.className = "bold";
+    label.className = "field-label";
     label.textContent = fieldName;
 
- 
-    pTag.append(label, `: ${(fieldDescription)}`);
+    const description = document.createElement("span");
+    description.className = "field-value bold";
+    description.textContent = fieldDescription;
+
+    pTag.append(label, ": ", description);
+    if (!divToAddTo) return;
+
     divToAddTo.appendChild(pTag);
 }
 

--- a/static/js/card/cardBuilder.js
+++ b/static/js/card/cardBuilder.js
@@ -1,0 +1,357 @@
+
+import { checkIfHTMLElement } from "../utils.js";
+import { logError, warnError } from "../logger.js";
+
+
+
+
+const CARD_IMAGES = {
+
+    visa: {
+        src: "../static/images/icons/visa.svg",
+        alt: "Visa card logo",
+        brand: "visa",
+       
+    },
+
+    mastercard: {
+        src: "../static/images/icons/mastercard.svg",
+        alt: "Mastercard logo",
+        brand: "mastercard",
+    },
+
+    discover: {
+        src: "../static/images/icons/discover.svg",
+        alt: "Discover logo",
+        brand: "discover",
+    }
+    
+}
+
+
+export const cardImplementer = {
+
+    /**
+     * Creates a new card element with the specified details.
+     *
+     * This function delegates the creation of a single card element to another function, `createSingleCreateCard`, 
+     * which takes care of the details of how the card is structured.
+     *
+     * @function createCard
+     * @param {Object} cardDetails - An object containing the details to create the card.
+     * @returns {HTMLElement} The newly created card element.
+     */
+    createCardDiv: (cardDetails) => {
+        return createSingleCreateCard(cardDetails);
+    },
+
+    
+    /**
+     * Places a card element into a specified location within the DOM.
+     *
+     * This function checks if both the location and card div elements are valid HTML elements before appending
+     * the card div to the location div. If either element is invalid, an error is logged. Optionally, it can 
+     * clear the location div before appending the new card div.
+     *
+     * @function placeCardDivIn
+     * @param {HTMLElement} locationDiv - The DOM element where the card div should be appended.
+     * @param {HTMLElement} cardDiv - The card div element that will be added to the location div.
+     * @param {boolean} [clearBeforeAppend=false] - If true, clears the location div before appending the card div.
+     */
+
+    placeCardDivIn: (locationDiv, cardDiv, clearBeforeAppend = false) => {
+
+        if (!checkIfHTMLElement(locationDiv, "Location card div") ||  !checkIfHTMLElement(cardDiv, "Card div element")) {
+            logError("cards.placeCardDivIn", "An error occurred trying to place card div element inside the given location");
+            return;
+        }
+
+        try {
+            if (clearBeforeAppend) {
+                locationDiv.innerHTML = "";
+              
+            }
+            locationDiv.appendChild(cardDiv);
+            return true;
+        } catch (error) {
+            logError("cards.placeCardDivIn", `An error occurred while appending the card div: ${error.message}`);
+            return false;
+        }
+    },
+
+};
+
+
+
+
+ /* Creates and returns a DOM element representing a single bank card.
+ *
+ * @param {Object} cardDetails - Card data used to build the card UI.
+ * @returns {HTMLDivElement} The fully constructed card element.
+ */
+export function createSingleCreateCard(cardDetails) {
+    const cardDiv = document.createElement("div");
+
+    // Build modular sections
+    cardDiv.appendChild(createCardHeadDiv(cardDetails));
+    cardDiv.appendChild(createCardBodyDiv(cardDetails));
+    cardDiv.appendChild(createFooterDiv(cardDetails));
+
+    // Main card classes
+    cardDiv.classList.add(
+        "bank-card",
+        `credit-${cardDetails.cardBrand.toLowerCase()}-card`
+    );
+
+    cardDiv.setAttribute(
+        "aria-label",
+        `${cardDetails.bankName} ${cardDetails.cardBrand} ${cardDetails.cardType}, balance ${cardDetails.cardAmount}`
+    );
+
+    // Create overlay div (will be reused for blocked status)
+    const cardOverlay = document.createElement("div");
+    cardOverlay.id = `card_${cardDetails.id}`;
+    cardDiv.appendChild(cardOverlay);
+
+  
+    if (cardDetails.isCardBlocked) applyCardBlockStatus(cardDiv, cardDetails);
+
+    return cardDiv;
+}
+
+/**
+ * Creates the card header section containing bank info and card logo.
+ *
+ * @param {Object} cardDetails - Card data.
+ * @returns {HTMLDivElement} Card header element.
+ */
+function createCardHeadDiv(cardDetails) {
+    const headDiv = document.createElement("div");
+    headDiv.classList.add("card-head");
+
+    const infoDiv = document.createElement("div");
+    infoDiv.classList.add("card-head-info");
+    infoDiv.innerHTML = `
+        <h3>${cardDetails.bankName}</h3>
+        <p class="bank-card-amount">${cardDetails.cardAmount}</p>
+    `;
+
+    const logoDiv = document.createElement("div");
+    logoDiv.classList.add("card-type-logo", "flex", "flex-end");
+    logoDiv.appendChild(createImageElementBasedOnCardType(cardDetails));
+
+    headDiv.appendChild(infoDiv);
+    headDiv.appendChild(logoDiv);
+
+    return headDiv;
+}
+
+
+/**
+ * Creates the main card body section (chip, type, and number).
+ *
+ * @param {Object} cardDetails - Card data.
+ * @returns {HTMLDivElement} Card body element.
+ */
+function createCardBodyDiv(cardDetails) {
+    const bodyDiv = document.createElement("div");
+    bodyDiv.classList.add("card-body");
+
+    // Chip
+    const chipDiv = document.createElement("div");
+    chipDiv.classList.add("chip");
+    chipDiv.innerHTML = `<img src="/static/images/icons/sim-card-chip.svg" alt="Card chip">`;
+
+    // Card type
+    const typeDiv = document.createElement("div");
+    typeDiv.className = "credit-transaction-type flex flex-end";
+    typeDiv.innerHTML = `<span>${cardDetails.cardType}</span>`;
+
+    // Card number
+    const numberDiv = document.createElement("div");
+    numberDiv.className = "card-number flex flex-end";
+    numberDiv.innerHTML = `<span class="card-number">${cardDetails.cardNumber}</span>`;
+
+    bodyDiv.appendChild(chipDiv);
+    bodyDiv.appendChild(typeDiv);
+    bodyDiv.appendChild(numberDiv);
+
+    return bodyDiv;
+}
+
+
+
+/**
+ * Creates the card footer section with cardholder name and expiry date.
+ *
+ * @param {Object} cardDetails - Card data.
+ * @returns {HTMLDivElement} Card footer element.
+ */
+function createFooterDiv(cardDetails) {
+    const footerDiv = document.createElement("div");
+    footerDiv.classList.add("card-footer", "flex", "flex-space-between");
+
+    const nameDiv = document.createElement("div");
+    nameDiv.className = "card-name";
+    nameDiv.textContent = cardDetails.cardName;
+
+    const expiryDiv = document.createElement("div");
+    expiryDiv.className = "card-expiry-date";
+    expiryDiv.innerHTML = `<p>Expiry date: ${cardDetails.expiryMonth} ${cardDetails.expiryYear}</p>`;
+
+    footerDiv.appendChild(nameDiv);
+    footerDiv.appendChild(expiryDiv);
+
+    return footerDiv;
+}
+
+
+/**
+ * Returns an image element based on the card brand.
+ *
+ * @param {Object} cardDetails - Card data.
+ * @returns {HTMLImageElement} Card brand image element.
+ */
+function createImageElementBasedOnCardType(cardDetails) {
+    const img = document.createElement("img");
+    const cardBrand = cardDetails.cardBrand.toLowerCase();
+
+    if (CARD_IMAGES[cardBrand]) {
+        img.src = CARD_IMAGES[cardBrand].src;
+        img.alt = CARD_IMAGES[cardBrand].alt;
+    } else {
+        img.src = "";
+        img.alt = "";
+    }
+
+    img.className = "card-icon";
+    return img;
+}
+
+
+
+/**
+ * Applies a blocked overlay and styling to a card element.
+ *
+ * @param {HTMLElement} cardDiv - Card container element.
+ * @param {Object} cardDetails - Card data.
+ */
+export function applyCardBlockStatus(cardDiv, cardDetails) {
+    if (!checkIfHTMLElement(cardDiv, "Card div element")) return;
+
+    const overlayId = `card_${cardDetails.id}`;
+    let cardOverlay = cardDiv.querySelector(`#${overlayId}`);
+
+  
+    if (!cardOverlay) {
+        cardOverlay = document.createElement("div");
+        cardOverlay.id = overlayId;
+        cardDiv.appendChild(cardOverlay);
+    }
+
+    cardOverlay.className = "card-overlay"; // reset classes
+    cardOverlay.textContent = "Blocked";
+
+    cardDiv.classList.remove("card-is-blocked", "card-not-blocked");
+    cardDiv.classList.add("card-is-blocked");
+}
+
+
+
+
+/**
+ * Removes the blocked overlay and styling from a card element.
+ *
+ * @param {HTMLElement} cardDiv - Card container element.
+ * @param {Object} cardDetails - Card data.
+ */
+export function removeCardBlockStatus(cardDiv, cardDetails) {
+    if (!checkIfHTMLElement(cardDiv, "Card div element")) return;
+
+    const overlayId = `card_${cardDetails.id}`;
+    const cardOverlay = cardDiv.querySelector(`#${overlayId}`);
+
+    if (cardOverlay) {
+        cardOverlay.classList.remove("card-overlay");
+        cardOverlay.textContent = "";
+    }
+
+    cardDiv.classList.remove("card-is-blocked");
+}
+
+
+
+
+export function createCardDetails(cardDetails) {
+    
+    const fragment  = document.createDocumentFragment()
+   
+   const cardFields = [
+     { fieldName: "Card ID", fieldValue: cardDetails.cardId },
+    { fieldName: "Bank", fieldValue: cardDetails.bankName },
+    { fieldName: "Card Name", fieldValue: cardDetails.cardName },
+    { fieldName: "Card Number", fieldValue: cardDetails.cardNumber },
+    { fieldName: "Card Amount", fieldValue: cardDetails.cardAmount },
+    { fieldName: "Card Brand", fieldValue: cardDetails.cardBrand },
+    { fieldName: "Card Type", fieldValue: cardDetails.cardType },
+    { fieldName: "CVC", fieldValue: cardDetails.cardCVC },
+    { fieldName: "Expiry Month", fieldValue: cardDetails.expiryMonth },
+    { fieldName: "Expiry Year", fieldValue: cardDetails.expiryYear },
+    { fieldName: "Creation Date", fieldValue: cardDetails.cardCreationDate },
+    { fieldName: "Issue Date", fieldValue: cardDetails.issueDate }
+];
+
+
+    const isActiveElement    = updateCardActiveStatus(cardDetails, document.createElement("p")); 
+    cardFields.forEach((cardField) => createFieldElement(cardField.fieldName, cardField.fieldValue, fragment))
+
+    createFieldElement("Can the card be used", cardDetails.cardStatus, fragment);
+    fragment.appendChild(isActiveElement)
+    return fragment;
+    
+
+}
+
+
+function createFieldElement(fieldName, fieldDescription, divToAddTo) {
+    const pTag = document.createElement("p");
+
+    const label = document.createElement("span");
+    label.className = "bold";
+    label.textContent = fieldName;
+
+ 
+    pTag.append(label, `: ${(fieldDescription)}`);
+    divToAddTo.appendChild(pTag);
+}
+
+
+
+/**
+ * Updates the UI element to reflect whether a card is active or inactive.
+ *
+ * The function checks the card's active status and applies the appropriate
+ * CSS class to the provided DOM element to visually indicate the state.
+ *
+ * @param {Object} cardDetails - Object containing card information.
+ * @param {boolean} cardDetails.isCardActive - Indicates whether the card is active.
+ * @param {HTMLElement} cardActiveElement - DOM element displaying the card's status.
+ *
+ * @returns {void}
+ */
+
+function updateCardActiveStatus(cardDetails, cardActiveElement) {
+
+
+    if (cardDetails.cardStatus === "true") {
+        cardActiveElement.className = "active-text";
+        cardActiveElement.textContent = "The card is active";
+        return cardActiveElement;
+    } 
+    
+    cardActiveElement.className = "deactivate-text";
+    cardActiveElement.textContent = "The card is blocked";
+    return cardActiveElement;
+
+    
+}

--- a/static/js/dashboard/bank-dashboard.js
+++ b/static/js/dashboard/bank-dashboard.js
@@ -29,9 +29,13 @@ const addFundsToBankPanel         = document.getElementById("bank-account-add-fu
 const viewBankTransacionPanel     = document.getElementById("bank-account-view-transactions");
 const fullCardDetailsContainer    = document.getElementById("full-card-details");
 const cardDetailsContainer        = document.getElementById("full-card-details-info");
+const bankCardButtons             = document.querySelector(".view-card-panel-buttons");
+const creditCardsNodeElements     = document.querySelectorAll(".bank-card");
+const viewExtraCardInfo           = document.getElementById("view-more-bank-card");
+const extraCardInfoPanel           = document.getElementById("view-card-panel");
 
 
-console.log(cardDetailsContainer)
+
 
 const MAX_TRANSFER_AMOUNT = 1_000_000;
 let walletModalStep2Button;
@@ -63,6 +67,42 @@ dashboardProfileElement.addEventListener("click", handleDropDownMenu);
 dashboard.addEventListener("click", handleDelegation);
 walletAuthForm.addEventListener("submit", handleWalletAuthForm);
 amountInputField.addEventListener("keydown", handleEnter)
+
+
+
+// records which card was clicked
+const selectedCardStore = {
+    element: null,
+
+    /**
+     * Stores the selected card element.
+     * Only accepts a valid HTMLElement to prevent invalid state.
+     *
+     * @param {HTMLElement|null} cardElement - The card DOM element to store.
+     *                                           Pass null to clear selection.
+     */
+    set(cardElement) {
+
+        if (!checkIfHTMLElement(cardElement, "selectedCardStore", true)) return;
+        this.element = cardElement;
+    },
+
+    /**
+     * Returns the currently stored card element.
+     *
+     * @returns {HTMLElement|null} The selected card element or null if none is selected.
+     */
+    get() {
+        return this.element;
+    },
+
+    /**
+     * Clears the stored card selection.
+     */
+    clear() {
+        this.element = null;
+    }
+};
 
 
 
@@ -330,6 +370,9 @@ function handleDelegation(e) {
     handleTableHightlight(e);
     handleToggleViewBankTransactionPanel(e);
     handleCardClick(e);
+    handleViewMoreInfoCardClick(e);
+    handleCloseViewFullCardDetails(e);
+    handleCardSelectionTimeout(e)
     
     
 
@@ -746,44 +789,19 @@ function handleBankCardTypes(e){
     const expectedAccountTypes = ["savings-account", "debit-cards", "wallet"]
 
     if(!expectedAccountTypes.includes(accountCard?.dataset.account)) return;
+    if (!checkIfHTMLElement(accountCard, "account card")) return;
 
-    deselectBankCardTypes(accountCard);
-    selectBankCardTypes(accountCard)
+    deselectAllElements(bankCardSelectionTypes, "active");
+    selectElement(accountCard, "active")
    
 }
 
 
-/**
- * Deselects all bank card types by removing the "active" class from each card element.
- * 
- * Note there must be an "active" class selector in the CSS style file. If it is called by
- * another name, that name must be passed to CSSelector variable
- * @param {HTMLElement} accountCard - The account card element to validate before deselecting others.
- */
-function deselectBankCardTypes(accountCard, cssSelectorElement = "active") {
-
-    if (!checkIfHTMLElement(accountCard, "account card")) return;
-
-    bankCardSelectionTypes.forEach((cardElement) => {
-        cardElement.classList.remove(cssSelectorElement);
-    })
-    
-}
 
 
-/**
- * Selects a specific bank card type by adding the "active" class (or custom CSS selector file) to it.
- * If a custom is used, it must be passed as a paramenter to the function
- * 
- * The function first validates that the provided element is a valid HTML element.
- * If valid, it adds the class defined in `cssSelectorElement` to visually indicate selection.
- * 
- * @param {HTMLElement} accountCard - The account card element to be selected.
- */
-function selectBankCardTypes(accountCard, cssSelectorElement="active") {
-    if (!checkIfHTMLElement(accountCard)) return;
-    accountCard.classList.add(cssSelectorElement)
-}
+
+
+
 
 
 
@@ -954,7 +972,6 @@ function handleToggleViewBankTransactionPanel(e) {
     const clickedCloseBtn = e.target.closest(`#${closePanelId}`);
 
 
-
     if (!clickedViewBtn && !clickedCloseBtn) return;
 
 
@@ -963,34 +980,66 @@ function handleToggleViewBankTransactionPanel(e) {
          return;
     }
    
+
     toggleElement({element: viewBankTransacionPanel, show: false});
 
 
 }
 
 
-
 function handleCardClick(e) {
-    viewFullCardDetails(e)
+    processCardClicked(e)
 }
 
 
-function viewFullCardDetails(e) {
+function handleViewMoreInfoCardClick(e) {
+    const viewMoreButtonId = "view-more-bank-card";
+  
+    if (e.target.id !== viewMoreButtonId) return;
+    
+    toggleElement({element: extraCardInfoPanel, show: true});
+    viewFullCardDetails();
+}
 
+
+
+function processCardClicked(e) {
     const bankCard = "bank-card";
-
     const bankCardElement = e.target.closest(`.${bankCard}`);
 
     if (!bankCardElement) return;
+    const cardVisibleSelector="is-selected";
 
-    const bankName = bankCardElement.querySelector(".card-head-info h3").textContent;
-    const amount   = bankCardElement.querySelector(".bank-card-amount").textContent;
-    const cardType = bankCardElement.querySelector(".card-type").textContent.trim();
+    deselectAllCards();
+    selectElement(bankCardElement, cardVisibleSelector)
+   
+    selectedCardStore.set(bankCardElement);
+    toggleElement({element: viewExtraCardInfo})
+}
+
+
+function deselectAllCards(cardVisibleSelector="is-selected") {
+    deselectAllElements(creditCardsNodeElements, cardVisibleSelector)
+}
+
+
+function viewFullCardDetails() {
+
+    const bankCardElement = selectedCardStore.get();
+
+    if (!bankCardElement) return;
+
+    toggleElement({element: viewExtraCardInfo, show: false})
+  
+   
+    const bankName   = bankCardElement.querySelector(".card-head-info h3").textContent;
+    const amount     = bankCardElement.querySelector(".bank-card-amount").textContent;
+    const cardType   = bankCardElement.querySelector(".card-type").textContent.trim();
     const cardNumber = bankCardElement.querySelector(".card-number").textContent;
-    const cardName  =  bankCardElement.querySelector(".card-name").textContent;
+    const cardName   =  bankCardElement.querySelector(".card-name").textContent;
     const expiryDate = bankCardElement.querySelector(".card-expiry-date").textContent;
- 
-    const [month, year] = expiryDate.split("Expiry date:")
+    
+    const [month, year] = expiryDate.split("Expiry date: ")
   
     const cardDetails = {
         cardId: bankCardElement.dataset.cardId,
@@ -1018,5 +1067,122 @@ function viewFullCardDetails(e) {
 
    cardImplementer.placeCardDivIn(cardDetailsContainer, cardDetailsElement, true);
 
+   removeBankCardButtonsFromCardExtraView(false);
 
+}
+
+
+
+function handleCloseViewFullCardDetails(e) {
+    if (e.target.id !== "card-close-btn") return;
+
+    toggleElement({element: extraCardInfoPanel, show: false});
+    deselectAllCards();
+}
+
+
+
+function removeBankCardButtonsFromCardExtraView(remove=true) {
+
+    if (!bankCardButtons) return null;
+    toggleElement({element: bankCardButtons, show: !remove})
+}
+
+
+
+
+/**
+ * Removes a CSS class from all elements in a collection.
+ *
+ * Typically used to deselect or reset UI elements that were
+ * previously marked with a given class (e.g., removing a
+ * "selected" state from cards).
+ *
+ * @param {NodeList|Array<HTMLElement>} elements
+ * A collection of DOM elements, commonly returned by
+ * querySelectorAll().
+ *
+ * @param {string} cssClass
+ * The CSS class to remove from each element.
+ *
+ * @returns {void}
+ */
+function deselectAllElements(elements, cssClass) {
+
+    // Ensure the function receives a collection of elements that can be used by forEach loop
+    if (!elements || typeof elements.forEach !== "function") return;
+
+    if (typeof cssClass !== "string" || cssClass.length === 0) return;
+
+    elements.forEach((element) => {
+        element.classList.remove(cssClass);
+    });
+}
+
+
+
+/**
+ * Adds a CSS class to a DOM element to mark it as selected or active.
+ *
+ * Commonly used to visually highlight UI elements such as cards,
+ * buttons, or list items when they are selected by the user.
+ *
+ * @param {HTMLElement} elementToSelect
+ * The DOM element that should receive the CSS class.
+ *
+ * @param {string} [cssSelectorElement="active"]
+ * The CSS class to add to the element. Defaults to "active".
+ * 
+ * Note: 
+ * There must a CSS rule that determines how the element should be highlighted
+ * and that name should be passed to the function.
+ *
+ * @returns {void}
+ */
+function selectElement(elementToSelect, cssSelectorElement = "active") {
+    if (!checkIfHTMLElement(elementToSelect)) return;
+    elementToSelect.classList.add(cssSelectorElement);
+}
+
+
+
+/**
+ * handleCardSelectionTimeout
+ *
+ * Automatically deselects any selected card if the card details panel 
+ * ("view-card-panel") is not opened within a specified timeout.
+ *
+ * This function waits for 5 seconds (`MILLI_SECONDS`) and then:
+ *   1. Deselects all cards using `deselectAllCards()`.
+ *   2. Hides the "view more bank card" element using `toggleElement()`.
+ *
+ * The timeout is only applied if the extra card info panel is currently hidden.
+ *
+ * Usage:
+ * Call this function after a card is selected to ensure that a card does 
+ * not remain selected indefinitely without the user viewing its details.
+ *
+ * @function
+ * @returns {void} Does not return any value.
+ */
+
+function handleCardSelectionTimeout() {
+    const MILLI_SECONDS = 5000;
+
+ 
+    // Must query elements dynamically each time because their visibility can change
+    const viewExtraCardInfo  = document.getElementById("view-more-bank-card");
+    const extraCardInfoPanel = document.getElementById("view-card-panel");
+
+
+    const isSideCardPanelOpen  = getComputedStyle(extraCardInfoPanel).display;
+   
+    if (isSideCardPanelOpen === "none") {
+      
+        setTimeout(() => {
+            deselectAllCards();
+            toggleElement({element: viewExtraCardInfo, show: false})
+        }, MILLI_SECONDS)
+    }
+    
 }

--- a/static/js/dashboard/bank-dashboard.js
+++ b/static/js/dashboard/bank-dashboard.js
@@ -1,6 +1,8 @@
 import { sanitizeText } from "../utils.js";
 import { AlertUtils } from "../alerts.js";
 import { checkIfHTMLElement } from "../utils.js";
+import { cardImplementer, createCardDetails } from "../card/cardBuilder.js";
+
 
 
 const connectWalletModal          = document.getElementById("connect-wallet-modal");
@@ -25,7 +27,11 @@ const amountInputField            = document.getElementById("account-card__amoun
 const bankCardSelectionTypes      = document.querySelectorAll(".account-card");
 const addFundsToBankPanel         = document.getElementById("bank-account-add-funds");
 const viewBankTransacionPanel     = document.getElementById("bank-account-view-transactions");
+const fullCardDetailsContainer    = document.getElementById("full-card-details");
+const cardDetailsContainer        = document.getElementById("full-card-details-info");
 
+
+console.log(cardDetailsContainer)
 
 const MAX_TRANSFER_AMOUNT = 1_000_000;
 let walletModalStep2Button;
@@ -323,6 +329,7 @@ function handleDelegation(e) {
     handleToggleAddFundsPanel(e);
     handleTableHightlight(e);
     handleToggleViewBankTransactionPanel(e);
+    handleCardClick(e);
     
     
 
@@ -957,6 +964,59 @@ function handleToggleViewBankTransactionPanel(e) {
     }
    
     toggleElement({element: viewBankTransacionPanel, show: false});
+
+
+}
+
+
+
+function handleCardClick(e) {
+    viewFullCardDetails(e)
+}
+
+
+function viewFullCardDetails(e) {
+
+    const bankCard = "bank-card";
+
+    const bankCardElement = e.target.closest(`.${bankCard}`);
+
+    if (!bankCardElement) return;
+
+    const bankName = bankCardElement.querySelector(".card-head-info h3").textContent;
+    const amount   = bankCardElement.querySelector(".bank-card-amount").textContent;
+    const cardType = bankCardElement.querySelector(".card-type").textContent.trim();
+    const cardNumber = bankCardElement.querySelector(".card-number").textContent;
+    const cardName  =  bankCardElement.querySelector(".card-name").textContent;
+    const expiryDate = bankCardElement.querySelector(".card-expiry-date").textContent;
+ 
+    const [month, year] = expiryDate.split("Expiry date:")
+  
+    const cardDetails = {
+        cardId: bankCardElement.dataset.cardId,
+        bankName: bankName,
+        cardBrand: bankCardElement.dataset.cardBrand,
+        cardAmount: amount,
+        cardType: cardType,
+        cardNumber: cardNumber,
+        expiryMonth: month,
+        expiryYear: year,
+        cardName: cardName,
+        issueDate: bankCardElement.dataset.issued,
+        cardCreationDate: bankCardElement.dataset.creationDate,
+        cardCVC: bankCardElement.dataset.cvc,
+    }
+
+   const card = cardImplementer.createCardDiv(cardDetails);
+   cardImplementer.placeCardDivIn(fullCardDetailsContainer, card, true)
+
+   // Add the card details to the field
+ 
+   cardDetails.cardStatus   = bankCardElement.dataset.isActive;
+   cardDetails.cvc          = "***"
+   const cardDetailsElement = createCardDetails(cardDetails);
+
+   cardImplementer.placeCardDivIn(cardDetailsContainer, cardDetailsElement, true);
 
 
 }

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -2,10 +2,16 @@ import { logError } from "./logger.js";
 import { specialChars } from "./specialChars.js";
 
   
-export function checkIfHTMLElement(element, elementName = "Unknown") {
+export function checkIfHTMLElement(element, elementName = "Unknown", warn = false) {
     if (!(element instanceof HTMLElement || element instanceof DocumentFragment)) {
-        console.error(`Could not find the element: '${elementName}'. Ensure the selector is correct.`);
-        return false;
+
+        if (warn) {
+             console.warn(`Could not find the element: '${elementName}'. Ensure the selector is correct.`);
+        } else {
+            console.error(`Could not find the element: '${elementName}'. Ensure the selector is correct.`);
+        }
+         return false;
+       
     }
     return true;
 }


### PR DESCRIPTION
## feat(dashboard): Allow users to view more card information when a card is clicked

## Goal

The goal of this commit is to introduce the second part of the **View Card** feature in the dashboard.  
Users can now click a card on the dashboard to view additional information.

This extra information is not shown on the dashboard cards to avoid overwhelming the user.  
In the detailed view, users can see all the card information and will eventually be able to block cards, add funds, or transfer funds.


## Changes

- Added the JS functions that enable to function to work
- Added CSS styling for the card details


## Workflow

1. User navigates to the **Bank Cards panel** in the dashboard.
2. User clicks a card.
3. Full card details are displayed when the user clicks the view card details.
4. User hits view card details to view more
5. User hits close button to exit out


## Workflow 2
1. User navigates to the **Bank Cards panel** in the dashboard.
2. User clicks a card.
3. User doesn't click the view card details
4. After 5 seconds the card is unselected


## TODO

- Finish the panel side buttons right now only the cancel button is functional.

## Notes

- Page responsiveness will be handled later.
- Card numbers are not yet masked; this will be handled when backend integration is implemented.
- Current cards are dummy data for UI testing and will be replaced with dynamic data.
- Like all pages, the page is not yet responsive.
